### PR TITLE
:wrench: Add git submodule initialization to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+git submodule update --init --recursive
+
 bundle install
 
 # Do any other automated setup that you need to do here


### PR DESCRIPTION
## Summary

- Add `git submodule update --init --recursive` to bin/setup script before bundle install
- Ensures RuboCop configuration submodule is properly initialized during development setup
- Follows best practices for recursive submodule initialization

## Test plan

- [x] Verify bin/setup script includes submodule initialization
- [x] Test that RuboCop configuration is available after running bin/setup
- [x] Ensure existing functionality remains intact

:robot: Generated with [Claude Code](https://claude.ai/code)