### PR TITLE
:test_tube: Fix CLI test config file isolation

### DIFF
--- a/spec/fasti/cli_spec.rb
+++ b/spec/fasti/cli_spec.rb
@@ -10,6 +10,19 @@ RSpec.describe Fasti::CLI do
   let(:exe_path) { File.expand_path("../../exe/fasti", __dir__) }
 
   describe "#run" do
+    # Isolate each test from the user's actual config file (~/.config/fastirc)
+    # by redirecting XDG_CONFIG_HOME to a temporary directory.
+    # This ensures tests are deterministic and don't depend on external configuration.
+    around do |example|
+      old_xdg_config_home = ENV["XDG_CONFIG_HOME"]
+      temp_config_dir = Dir.mktmpdir
+      ENV["XDG_CONFIG_HOME"] = temp_config_dir
+      example.run
+    ensure
+      ENV["XDG_CONFIG_HOME"] = old_xdg_config_home
+      FileUtils.rm_rf(temp_config_dir) if temp_config_dir
+    end
+
     context "with --help option" do
       it "displays help message" do
         result = cmd.run("ruby", exe_path, "--help")
@@ -214,18 +227,11 @@ RSpec.describe Fasti::CLI do
       around do |example|
         old_lc_all = ENV["LC_ALL"]
         old_lang = ENV["LANG"]
-        old_xdg_config_home = ENV["XDG_CONFIG_HOME"]
-
-        # Use temporary directory to avoid reading actual config file
-        temp_config_dir = Dir.mktmpdir
-        ENV["XDG_CONFIG_HOME"] = temp_config_dir
 
         example.run
       ensure
         ENV["LC_ALL"] = old_lc_all
         ENV["LANG"] = old_lang
-        ENV["XDG_CONFIG_HOME"] = old_xdg_config_home
-        FileUtils.rm_rf(temp_config_dir) if temp_config_dir
       end
 
       it "detects country from LC_ALL" do


### PR DESCRIPTION
Fix failing CLI test that was affected by user's actual config file

## Summary
- Fix failing CLI test that was affected by user's actual config file
- Add shared around hook to isolate tests from ~/.config/fastirc
- Remove duplicate around hooks following DRY principle
- Add explanatory comments for config file isolation

## Background
The CLI test was failing because it was reading the user's actual ~/.config/fastirc config file during test execution. If a user had start_of_week: monday configured, the test expecting "Su Mo Tu We Th Fr Sa" (Sunday start) would fail.

## Changes
1. **Shared isolation**: Added a common around hook at the describe "#run" level that redirects XDG_CONFIG_HOME to a temporary directory
2. **DRY refactoring**: Removed duplicate around hooks from individual test contexts
3. **Documentation**: Added clear comments explaining the purpose of config file isolation
4. **Maintained existing functionality**: Preserved specialized around hooks for environment variable testing

## Test Results
- All 79 tests now pass consistently
- Tests are deterministic regardless of user's actual config file
- No behavioral changes to the application itself

:robot: Generated with [Claude Code](https://claude.ai/code)