### PR TITLE
Refactor calendar styling from culture-specific to neutral approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,13 @@ Create a configuration file at `~/.config/fastirc` (or `$XDG_CONFIG_HOME/fastirc
 
 Command line options override configuration file settings.
 
-### Color Coding
+### Styling
 
-Fasti uses ANSI colors to highlight different types of days:
+Fasti uses ANSI text styling to highlight different types of days:
 
-- **Red**: Sundays and holidays (rest days)
-- **Blue**: Saturdays  
-- **Inverted**: Today's date (combined with above colors when applicable)
-- **Normal**: Regular weekdays
-
-*Note: The current color scheme reflects Japanese calendar culture but works well internationally. Future versions may include configurable color themes.*
+- **Bold**: Sundays and holidays
+- **Inverted**: Today's date (combined with bold when applicable)
+- **Normal**: Regular weekdays (including Saturdays)
 
 ### Examples
 

--- a/lib/fasti/formatter.rb
+++ b/lib/fasti/formatter.rb
@@ -9,19 +9,10 @@ module Fasti
   # with ANSI color coding for holidays, weekends, and the current date.
   # Holiday detection is handled by the Calendar class using the holidays gem.
   #
-  # ## Color Coding
-  # - **Holidays**: Red text
-  # - **Saturdays**: Blue text
-  # - **Sundays**: Red text
-  # - **Today**: Inverted background/text colors (combined with above colors)
-  #
-  # **Note**: The current color scheme is heavily influenced by Japanese calendar culture
-  # (red for Sundays/holidays representing rest days, blue for Saturdays representing
-  # half-day work). Future versions may make color schemes configurable or
-  # culture-specific to better support international users. Additionally, different
-  # cultures have varying weekend patterns (e.g., Friday-Saturday in some Middle Eastern
-  # countries, Saturday-Sunday in most Western countries), which should be considered
-  # in future internationalization efforts.
+  # ## Styling
+  # - **Holidays**: Bold text
+  # - **Sundays**: Bold text
+  # - **Today**: Inverted background/text colors (combined with above styles)
   #
   # @example Basic month formatting
   #   formatter = Formatter.new
@@ -33,13 +24,10 @@ module Fasti
   #   puts formatter.format_year(2024, start_of_week: :sunday, country: :jp)
   class Formatter
     # Style constants for different day types
-    SATURDAY_STYLE = Style.new(foreground: :blue)
-    private_constant :SATURDAY_STYLE
-
-    SUNDAY_STYLE = Style.new(foreground: :red)
+    SUNDAY_STYLE = Style.new(bold: true)
     private_constant :SUNDAY_STYLE
 
-    HOLIDAY_STYLE = Style.new(foreground: :red)
+    HOLIDAY_STYLE = Style.new(bold: true)
     private_constant :HOLIDAY_STYLE
 
     TODAY_STYLE = Style.new(inverse: true)
@@ -172,11 +160,10 @@ module Fasti
 
     # Formats a single day with appropriate color coding.
     #
-    # Applies ANSI color codes based on the day's characteristics:
+    # Applies ANSI styling based on the day's characteristics:
     # - Today: Inverted colors (combined with other formatting)
-    # - Holidays: Red text
-    # - Saturdays: Blue text
-    # - Sundays: Red text
+    # - Holidays: Bold text
+    # - Sundays: Bold text
     # - Regular days: No special formatting
     #
     # @param day [Integer, nil] Day of the month (1-31) or nil for empty cells
@@ -185,7 +172,7 @@ module Fasti
     #
     # @example
     #   format_day(15, calendar)    #=> "15" (regular day)
-    #   format_day(1, calendar)     #=> styled " 1" with red foreground (if Sunday/holiday)
+    #   format_day(1, calendar)     #=> styled " 1" with bold text (if Sunday/holiday)
     #   format_day(nil, calendar)   #=> "  " (empty cell)
     private def format_day(day, calendar)
       return "  " unless day
@@ -198,15 +185,13 @@ module Fasti
 
       # 1. Apply day-of-week style
       case date.wday
-      when 6 # Saturday
-        style >>= SATURDAY_STYLE
       when 0 # Sunday
         style >>= SUNDAY_STYLE
       else
-        # Weekdays (Monday-Friday) - no special day-of-week styling
+        # Weekdays (Monday-Saturday) - no special day-of-week styling
       end
 
-      # 2. Apply holiday style (overrides day-of-week color)
+      # 2. Apply holiday style (combines with existing styles)
       style >>= HOLIDAY_STYLE if calendar.holiday?(day)
 
       # 3. Apply today style (adds inverse to existing colors)

--- a/spec/fasti/formatter_spec.rb
+++ b/spec/fasti/formatter_spec.rb
@@ -5,14 +5,12 @@ require "paint"
 require "spec_helper"
 
 RSpec.describe Fasti::Formatter do
-  # ANSI color code constants for readable test expectations
+  # ANSI styling code constants for readable test expectations
   ANSI_ESCAPE = '\e\['
   ANSI_RESET = '\e\[0m'
-  ANSI_RED = '\e\[31m'
-  ANSI_BLUE = '\e\[34m'
+  ANSI_BOLD = '\e\[1m'
   ANSI_INVERSE = '\e\[7m'
-  ANSI_RED_INVERSE = '\e\[31;7m'
-  ANSI_BLUE_INVERSE = '\e\[34;7m'
+  ANSI_BOLD_INVERSE = '\e\[1;7m'
 
   let(:formatter) { Fasti::Formatter.new }
   let(:calendar) { Fasti::Calendar.new(2024, 6, country: :us) }
@@ -172,9 +170,9 @@ RSpec.describe Fasti::Formatter do
         # This is hard to test directly due to ANSI codes, but we can verify
         # the output contains Paint formatting
         output = formatter.format_month(january_calendar)
-        # The output should contain ANSI escape sequences for colors
-        # Should contain some ANSI formatting (holidays/weekends have colors)
-        expect(output).to match(/#{ANSI_RED}/) # Should have red for holidays/Sundays
+        # The output should contain ANSI escape sequences for bold styling
+        # Should contain some ANSI formatting (holidays/Sundays have bold)
+        expect(output).to match(/#{ANSI_BOLD}/) # Should have bold for holidays/Sundays
       end
     end
 
@@ -187,8 +185,8 @@ RSpec.describe Fasti::Formatter do
       it "highlights today's date" do
         output = formatter.format_month(calendar)
         # Should contain ANSI codes for inverse formatting
-        # June 15, 2024 is a Saturday, so should have blue + inverse
-        expect(output).to match(/#{ANSI_BLUE_INVERSE}\s*15#{ANSI_RESET}/)
+        # June 15, 2024 is a Saturday (no special styling) + inverse
+        expect(output).to match(/#{ANSI_INVERSE}\s*15#{ANSI_RESET}/)
       end
     end
   end
@@ -196,42 +194,16 @@ RSpec.describe Fasti::Formatter do
   describe "day styling behavior" do
     let(:july_2024) { Fasti::Calendar.new(2024, 7, country: :us) }
 
-    describe "Saturday styling" do
-      before do
-        # July 6, 2024 is a Saturday (not a holiday)
-        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1)) # Not today
-      end
-
-      it "applies blue color to Saturday when not today" do
-        output = formatter.format_month(july_2024)
-        # Extract the formatting for day 6 (Saturday)
-        # Should contain blue color code (34) but not inverse (7)
-        expect(output).to match(/#{ANSI_BLUE}\s*6#{ANSI_RESET}/)
-      end
-
-      context "when Saturday is today" do
-        before do
-          allow(Date).to receive(:today).and_return(Date.new(2024, 7, 6)) # Saturday
-        end
-
-        it "applies blue color with inverse formatting" do
-          output = formatter.format_month(july_2024)
-          # Should contain both blue (34) and inverse (7) codes
-          expect(output).to match(/#{ANSI_BLUE_INVERSE}\s*6#{ANSI_RESET}/)
-        end
-      end
-    end
-
     describe "Sunday styling" do
       before do
         # July 7, 2024 is a Sunday (not a holiday)
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1)) # Not today
       end
 
-      it "applies red color to Sunday when not today" do
+      it "applies bold styling to Sunday when not today" do
         output = formatter.format_month(july_2024)
-        # Should contain red color code (31) but not inverse (7)
-        expect(output).to match(/#{ANSI_RED}\s*7#{ANSI_RESET}/)
+        # Should contain bold code (1) but not inverse (7)
+        expect(output).to match(/#{ANSI_BOLD}\s*7#{ANSI_RESET}/)
       end
 
       context "when Sunday is today" do
@@ -239,10 +211,10 @@ RSpec.describe Fasti::Formatter do
           allow(Date).to receive(:today).and_return(Date.new(2024, 7, 7)) # Sunday
         end
 
-        it "applies red color with inverse formatting" do
+        it "applies bold with inverse formatting" do
           output = formatter.format_month(july_2024)
-          # Should contain both red (31) and inverse (7) codes
-          expect(output).to match(/#{ANSI_RED_INVERSE}\s*7#{ANSI_RESET}/)
+          # Should contain both bold (1) and inverse (7) codes
+          expect(output).to match(/#{ANSI_BOLD_INVERSE}\s*7#{ANSI_RESET}/)
         end
       end
     end
@@ -253,10 +225,10 @@ RSpec.describe Fasti::Formatter do
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1)) # Not today
       end
 
-      it "applies red color to holiday when not today" do
+      it "applies bold styling to holiday when not today" do
         output = formatter.format_month(july_2024)
-        # Should contain red color code (31) but not inverse (7)
-        expect(output).to match(/#{ANSI_RED}\s*4#{ANSI_RESET}/)
+        # Should contain bold code (1) but not inverse (7)
+        expect(output).to match(/#{ANSI_BOLD}\s*4#{ANSI_RESET}/)
       end
 
       context "when holiday is today" do
@@ -264,40 +236,38 @@ RSpec.describe Fasti::Formatter do
           allow(Date).to receive(:today).and_return(Date.new(2024, 7, 4)) # Holiday
         end
 
-        it "applies red color with inverse formatting" do
+        it "applies bold with inverse formatting" do
           output = formatter.format_month(july_2024)
-          # Should contain both red (31) and inverse (7) codes
-          expect(output).to match(/#{ANSI_RED_INVERSE}\s*4#{ANSI_RESET}/)
+          # Should contain both bold (1) and inverse (7) codes
+          expect(output).to match(/#{ANSI_BOLD_INVERSE}\s*4#{ANSI_RESET}/)
         end
       end
     end
 
-    describe "holiday on Saturday" do
-      # Need to find a Saturday holiday - using a different month/year
+    describe "holiday styling (various days)" do
+      # Using Veterans Day which falls on different weekdays in different years
       let(:november_2023) { Fasti::Calendar.new(2023, 11, country: :us) }
 
       before do
-        # November 11, 2023 is Veterans Day (Saturday, holiday)
+        # November 11, 2023 is Veterans Day (happens to be Saturday)
         allow(Date).to receive(:today).and_return(Date.new(2023, 11, 1)) # Not today
       end
 
-      it "applies red color (holiday overrides Saturday blue)" do
+      it "applies bold styling to holidays regardless of weekday" do
         output = formatter.format_month(november_2023)
-        # Should contain red color code (31), not blue (34)
-        expect(output).to match(/#{ANSI_RED}\s*11#{ANSI_RESET}/)
-        # Should not contain blue color for day 11
-        expect(output).not_to match(/#{ANSI_BLUE}\s*11#{ANSI_RESET}/)
+        # Should contain bold code (1) for holiday
+        expect(output).to match(/#{ANSI_BOLD}\s*11#{ANSI_RESET}/)
       end
 
-      context "when holiday Saturday is today" do
+      context "when holiday is today" do
         before do
-          allow(Date).to receive(:today).and_return(Date.new(2023, 11, 11)) # Holiday Saturday
+          allow(Date).to receive(:today).and_return(Date.new(2023, 11, 11)) # Holiday
         end
 
-        it "applies red color with inverse formatting" do
+        it "applies bold with inverse formatting" do
           output = formatter.format_month(november_2023)
-          # Should contain both red (31) and inverse (7) codes
-          expect(output).to match(/#{ANSI_RED_INVERSE}\s*11#{ANSI_RESET}/)
+          # Should contain both bold (1) and inverse (7) codes
+          expect(output).to match(/#{ANSI_BOLD_INVERSE}\s*11#{ANSI_RESET}/)
         end
       end
     end
@@ -328,9 +298,8 @@ RSpec.describe Fasti::Formatter do
           output = formatter.format_month(july_2024)
           # Should contain only inverse (7) code, no color codes
           expect(output).to match(/#{ANSI_INVERSE}\s*2#{ANSI_RESET}/)
-          # Should not have any color codes combined with inverse for regular day
-          expect(output).not_to match(/#{ANSI_RED_INVERSE}\s*2#{ANSI_RESET}/)
-          expect(output).not_to match(/#{ANSI_BLUE_INVERSE}\s*2#{ANSI_RESET}/)
+          # Should not have bold combined with inverse for regular day
+          expect(output).not_to match(/#{ANSI_BOLD_INVERSE}\s*2#{ANSI_RESET}/)
         end
       end
     end


### PR DESCRIPTION
## Summary

- Remove Saturday styling (blue color) - now treated as regular weekday  
- Change Sunday and holiday styling from red color to bold text
- Maintain today's inverse highlighting functionality
- Update documentation to remove Japanese culture references
- Refactor tests to match new neutral styling specification

## Changes Made

### Core Implementation (`lib/fasti/formatter.rb`)
- Removed `SATURDAY_STYLE` constant and Saturday-specific styling logic
- Changed `SUNDAY_STYLE` and `HOLIDAY_STYLE` from red color to bold text
- Updated documentation comments to reflect neutral approach
- Removed culture-specific explanatory notes

### Documentation (`README.md`)
- Updated "Color Coding" section to "Styling" 
- Removed references to Japanese calendar culture
- Updated styling descriptions to match new bold-based approach

### Tests (`spec/fasti/formatter_spec.rb`)
- Removed Saturday-specific test cases (2 tests)
- Updated all color-based expectations to bold-based expectations
- Renamed "holiday on Saturday" to "holiday styling (various days)"
- Updated ANSI code constants to match new styling

## Benefits

This change makes the calendar more internationally accessible by:
- Removing culture-specific color associations
- Using neutral bold styling for emphasis  
- Maintaining clear visual hierarchy without cultural bias
- Supporting better accessibility across terminal themes

## Test Results

- **RuboCop**: ✅ No violations detected
- **RSpec**: ✅ 111 examples, 0 failures  
- **Functionality**: ✅ Manual testing confirms proper styling

## Test Plan

- [x] Verify Sunday dates show in bold
- [x] Verify holiday dates show in bold  
- [x] Verify Saturday dates show with normal styling
- [x] Verify today's date shows with inverse highlighting
- [x] Verify inverse + bold combination works correctly
- [x] Confirm all existing tests pass
- [x] Confirm RuboCop compliance

:robot: Generated with [Claude Code](https://claude.ai/code)