### PR TITLE
Add comprehensive --style option for calendar customization

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,6 +19,7 @@ Metrics/AbcSize:
     - 'lib/fasti/cli.rb'
     - 'lib/fasti/formatter.rb'
     - 'lib/fasti/style.rb'
+    - 'lib/fasti/style_parser.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
@@ -57,7 +58,6 @@ Metrics/PerceivedComplexity:
   Exclude:
     - 'lib/fasti/formatter.rb'
     - 'lib/fasti/style.rb'
-
 
 # Configuration parameters: Max, CountAsOne.
 RSpec/ExampleLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,7 @@
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
   Exclude:
+    - 'spec/fasti/formatter_custom_styles_spec.rb'
     - 'spec/fasti/formatter_spec.rb'
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes, Max.
@@ -29,6 +30,7 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - 'lib/fasti/cli.rb'
+    - 'lib/fasti/style_parser.rb'
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/CyclomaticComplexity:
@@ -43,6 +45,7 @@ Metrics/MethodLength:
     - 'lib/fasti/cli.rb'
     - 'lib/fasti/formatter.rb'
     - 'lib/fasti/style.rb'
+    - 'lib/fasti/style_parser.rb'
 
 # Configuration parameters: Max, CountKeywordArgs, MaxOptionalParameters.
 Metrics/ParameterLists:
@@ -55,16 +58,19 @@ Metrics/PerceivedComplexity:
     - 'lib/fasti/formatter.rb'
     - 'lib/fasti/style.rb'
 
+
 # Configuration parameters: Max, CountAsOne.
 RSpec/ExampleLength:
   Exclude:
     - 'spec/fasti/calendar_spec.rb'
     - 'spec/fasti/cli_spec.rb'
+    - 'spec/fasti/formatter_custom_styles_spec.rb'
     - 'spec/fasti/formatter_spec.rb'
     - 'spec/fasti/style_spec.rb'
 
 RSpec/LeakyConstantDeclaration:
   Exclude:
+    - 'spec/fasti/formatter_custom_styles_spec.rb'
     - 'spec/fasti/formatter_spec.rb'
 
 # Configuration parameters: Max.
@@ -72,7 +78,9 @@ RSpec/MultipleExpectations:
   Exclude:
     - 'spec/fasti/calendar_spec.rb'
     - 'spec/fasti/cli_spec.rb'
+    - 'spec/fasti/formatter_custom_styles_spec.rb'
     - 'spec/fasti/formatter_spec.rb'
+    - 'spec/fasti/style_parser_spec.rb'
     - 'spec/fasti/style_spec.rb'
 
 # Configuration parameters: Max, AllowedGroups.
@@ -100,3 +108,4 @@ Style/SymbolProc:
 Layout/LineLength:
   Exclude:
     - 'lib/fasti/cli.rb'
+    - 'spec/fasti/style_parser_spec.rb'

--- a/lib/fasti.rb
+++ b/lib/fasti.rb
@@ -4,6 +4,7 @@ require_relative "fasti/calendar"
 require_relative "fasti/cli"
 require_relative "fasti/formatter"
 require_relative "fasti/style"
+require_relative "fasti/style_parser"
 require_relative "fasti/version"
 
 module Fasti

--- a/lib/fasti/cli.rb
+++ b/lib/fasti/cli.rb
@@ -232,13 +232,13 @@ module Fasti
     # @param options [Options] Parsed options
     private def generate_calendar(options)
       # Parse custom styles if provided
-      custom_styles = {}
+      styles = {}
       if options.style
         style_parser = StyleParser.new
-        custom_styles = style_parser.parse(options.style)
+        styles = style_parser.parse(options.style)
       end
 
-      formatter = Formatter.new(custom_styles:)
+      formatter = Formatter.new(styles:)
       start_of_week = options.start_of_week
 
       output = case options.format

--- a/lib/fasti/cli.rb
+++ b/lib/fasti/cli.rb
@@ -232,11 +232,7 @@ module Fasti
     # @param options [Options] Parsed options
     private def generate_calendar(options)
       # Parse custom styles if provided
-      styles = {}
-      if options.style
-        style_parser = StyleParser.new
-        styles = style_parser.parse(options.style)
-      end
+      styles = options.style ? StyleParser.new.parse(options.style) : {}
 
       formatter = Formatter.new(styles:)
       start_of_week = options.start_of_week

--- a/lib/fasti/formatter.rb
+++ b/lib/fasti/formatter.rb
@@ -186,27 +186,22 @@ module Fasti
       day_str = day.to_s.rjust(2)
       date = calendar.to_date(day)
 
-      # Build style through composition based on day characteristics
-      style = Style.new # Start with default style
+      # Collect applicable styles based on day characteristics
+      applicable_styles = []
 
       # 1. Apply day-of-week style
       weekday_key = %i[sunday monday tuesday wednesday thursday friday saturday][date.wday]
-      if @styles.key?(weekday_key)
-        style >>= @styles[weekday_key]
-      end
+      applicable_styles << @styles[weekday_key] if @styles.key?(weekday_key)
 
       # 2. Apply holiday style
-      if calendar.holiday?(day) && @styles.key?(:holiday)
-        style >>= @styles[:holiday]
-      end
+      applicable_styles << @styles[:holiday] if calendar.holiday?(day) && @styles.key?(:holiday)
 
       # 3. Apply today style
-      if date == Date.today && @styles.key?(:today)
-        style >>= @styles[:today]
-      end
+      applicable_styles << @styles[:today] if date == Date.today && @styles.key?(:today)
 
-      # 4. Apply the composed style
-      style.call(day_str)
+      # 4. Compose all styles and apply
+      final_style = applicable_styles.reduce(Style.new) {|acc, elem| acc >> elem }
+      final_style.call(day_str)
     end
   end
 end

--- a/lib/fasti/formatter.rb
+++ b/lib/fasti/formatter.rb
@@ -34,15 +34,15 @@ module Fasti
 
     # Creates a new formatter instance.
     #
-    # @param custom_styles [Hash<Symbol, Style>] Custom styles for different day types
+    # @param styles [Hash<Symbol, Style>] Custom styles for different day types
     #   Keys can be :sunday, :monday, ..., :saturday, :holiday, :today
-    #   If custom_styles is empty, DEFAULT_STYLES will be used
-    #   If custom_styles is provided, it completely replaces the defaults
+    #   If styles is empty, DEFAULT_STYLES will be used
+    #   If styles is provided, it completely replaces the defaults
     # @example
     #   Formatter.new  # Uses DEFAULT_STYLES
-    #   Formatter.new(custom_styles: { sunday: Style.new(foreground: :red) })  # Only sunday styled
-    def initialize(custom_styles: {})
-      @styles = custom_styles.empty? ? DEFAULT_STYLES : custom_styles
+    #   Formatter.new(styles: { sunday: Style.new(foreground: :red) })  # Only sunday styled
+    def initialize(styles: {})
+      @styles = styles.empty? ? DEFAULT_STYLES : styles
     end
 
     # Formats a single month calendar with headers and color coding.

--- a/lib/fasti/style_parser.rb
+++ b/lib/fasti/style_parser.rb
@@ -196,11 +196,7 @@ module Fasti
     # @param attributes [Hash<String, Object>] Hash of attribute names to values
     # @return [Style] New Style object
     private def create_style(attributes)
-      style_params = {}
-
-      attributes.each do |key, value|
-        style_params[key.to_sym] = value
-      end
+      style_params = attributes.transform_keys(&:to_sym)
 
       Style.new(**style_params)
     end

--- a/lib/fasti/style_parser.rb
+++ b/lib/fasti/style_parser.rb
@@ -64,11 +64,16 @@ module Fasti
     # @return [Array<Symbol, Hash>] Target symbol and attributes hash
     # @raise [ArgumentError] If entry format is invalid
     private def parse_entry(entry)
+      # Entry should not contain whitespace since it comes from split(/\s+/)
+      if entry.match?(/\s/)
+        raise ArgumentError, "Style entry should not contain whitespace: '#{entry}'"
+      end
+
       parts = entry.split(":", 2)
       raise ArgumentError, "Invalid style entry format: '#{entry}'" if parts.length != 2
 
-      target = parts[0].strip
-      attributes_str = parts[1].strip
+      target = parts[0]
+      attributes_str = parts[1]
 
       raise ArgumentError, "Invalid target: '#{target}'" unless VALID_TARGETS.include?(target)
 
@@ -95,8 +100,14 @@ module Fasti
           attributes[attribute_name] = false
         when /\A(.+)=(.+)\z/
           # Handle key=value format
-          key = $1.strip
-          value = $2.strip
+          key = $1
+          value = $2
+
+          # Reject keys or values with whitespace
+          if key != key.strip || value != value.strip
+            raise ArgumentError, "Attribute keys and values cannot contain leading or trailing spaces: '#{attr}'"
+          end
+
           attributes[key] = parse_attribute_value(key, value)
         else
           # Handle simple boolean attributes (bold, italic, etc.)

--- a/lib/fasti/style_parser.rb
+++ b/lib/fasti/style_parser.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+module Fasti
+  # Parses style definition strings into Style objects for calendar formatting.
+  #
+  # This class handles the parsing of style definition strings in the format:
+  # "target:attribute=value,attribute,no-attribute target:attribute=value"
+  #
+  # Supported targets:
+  # - Weekdays: sunday, monday, tuesday, wednesday, thursday, friday, saturday
+  # - Special days: holiday, today
+  #
+  # Supported attributes:
+  # - Colors: foreground=color, background=color
+  # - Text effects: bold, italic, underline, underline=double, overline, blink, inverse, hide, faint
+  # - Negation: no-bold, no-italic, etc.
+  #
+  # @example Basic usage
+  #   parser = StyleParser.new
+  #   styles = parser.parse("sunday:bold,foreground=red holiday:bold today:inverse")
+  #   styles[:sunday] #=> Style.new(bold: true, foreground: :red)
+  #
+  # @example With negation
+  #   styles = parser.parse("sunday:foreground=red,no-bold saturday:no-italic")
+  #   styles[:sunday] #=> Style.new(foreground: :red, bold: false)
+  class StyleParser
+    # Valid target names that can be used in style definitions
+    VALID_TARGETS = %w[sunday monday tuesday wednesday thursday friday saturday holiday today].freeze
+    private_constant :VALID_TARGETS
+
+    # Valid color names for foreground and background
+    VALID_COLORS = %w[red green blue yellow magenta cyan white black default].freeze
+    private_constant :VALID_COLORS
+
+    # Valid boolean attributes that can be enabled/disabled
+    BOOLEAN_ATTRIBUTES = %w[bold faint italic overline blink inverse hide].freeze
+    private_constant :BOOLEAN_ATTRIBUTES
+
+    # Special attributes that can have specific values
+    SPECIAL_ATTRIBUTES = {"underline" => [true, false, :double]}.freeze
+    private_constant :SPECIAL_ATTRIBUTES
+
+    # Parses a style definition string into a hash of Style objects.
+    #
+    # @param style_string [String] Style definition string
+    # @return [Hash<Symbol, Style>] Hash mapping target symbols to Style objects
+    # @raise [ArgumentError] If the style string contains invalid syntax or values
+    #
+    # @example
+    #   parse("sunday:bold,foreground=red holiday:bold today:inverse")
+    #   #=> { sunday: Style.new(...), holiday: Style.new(...), today: Style.new(...) }
+    def parse(style_string)
+      return {} if style_string.nil? || style_string.strip.empty?
+
+      style_string.strip.split(/\s+/).each_with_object({}) do |entry, styles|
+        target, attributes_hash = parse_entry(entry)
+        styles[target] = create_style(attributes_hash)
+      end
+    end
+
+    # Parses a single style entry in the format "target:attributes"
+    #
+    # @param entry [String] Single style entry
+    # @return [Array<Symbol, Hash>] Target symbol and attributes hash
+    # @raise [ArgumentError] If entry format is invalid
+    private def parse_entry(entry)
+      parts = entry.split(":", 2)
+      raise ArgumentError, "Invalid style entry format: '#{entry}'" if parts.length != 2
+
+      target = parts[0].strip
+      attributes_str = parts[1].strip
+
+      raise ArgumentError, "Invalid target: '#{target}'" unless VALID_TARGETS.include?(target)
+
+      attributes = parse_attributes(attributes_str)
+      [target.to_sym, attributes]
+    end
+
+    # Parses attribute string into a hash of attribute names and values
+    #
+    # @param attributes_str [String] Comma-separated attribute string
+    # @return [Hash<String, Object>] Hash of attribute names to values
+    private def parse_attributes(attributes_str)
+      attributes = {}
+
+      attributes_str.split(",").each do |attr|
+        attr = attr.strip
+        next if attr.empty?
+
+        case attr
+        when /\Ano-(.+)\z/
+          # Handle no- prefix (negation)
+          attribute_name = $1
+          validate_boolean_attribute(attribute_name)
+          attributes[attribute_name] = false
+        when /\A(.+)=(.+)\z/
+          # Handle key=value format
+          key = $1.strip
+          value = $2.strip
+          attributes[key] = parse_attribute_value(key, value)
+        else
+          # Handle simple boolean attributes (bold, italic, etc.)
+          validate_boolean_attribute(attr)
+          attributes[attr] = true
+        end
+      end
+
+      attributes
+    end
+
+    # Parses an attribute value based on the attribute key
+    #
+    # @param key [String] Attribute name
+    # @param value [String] Attribute value
+    # @return [Object] Parsed value (Symbol, Boolean, etc.)
+    # @raise [ArgumentError] If the key or value is invalid
+    private def parse_attribute_value(key, value)
+      case key
+      when "foreground", "background"
+        parse_color_value(value)
+      when "underline"
+        parse_underline_value(value)
+      when *BOOLEAN_ATTRIBUTES
+        raise ArgumentError, "Boolean attributes should not use '=' syntax. Use '#{key}' or 'no-#{key}' instead"
+      else
+        raise ArgumentError, "Unknown attribute: '#{key}'"
+      end
+    end
+
+    # Parses a color value (color name or hex code)
+    #
+    # @param value [String] Color value
+    # @return [Symbol, String] Color as symbol or hex string
+    # @raise [ArgumentError] If color is invalid
+    private def parse_color_value(value)
+      # Check if it's a hex color (with or without #)
+      if value.match?(/\A#?\h{3}(?:\h{3})?\z/)
+        parse_hex_color(value)
+      elsif VALID_COLORS.include?(value)
+        value.to_sym
+      else
+        raise ArgumentError, "Invalid color: '#{value}'. Valid colors: #{VALID_COLORS.join(", ")}, or hex colors " \
+                             "(#RGB, #RRGGBB, RGB, RRGGBB)"
+      end
+    end
+
+    # Parses and normalizes hex color values
+    #
+    # @param value [String] Hex color value (with or without #, 3 or 6 digits)
+    # @return [String] Normalized 6-digit hex color with #
+    # @raise [ArgumentError] If hex color format is invalid
+    private def parse_hex_color(value)
+      # Remove # if present
+      hex_part = value.start_with?("#") ? value[1..] : value
+
+      case hex_part.length
+      when 3
+        # Expand 3-digit to 6-digit (F00 -> FF0000)
+        expanded = hex_part.chars.map {|c| c + c }.join
+        "##{expanded.upcase}"
+      when 6
+        "##{hex_part.upcase}"
+      else
+        raise ArgumentError, "Invalid hex color: '#{value}'. Use 3-digit (#RGB) or 6-digit (#RRGGBB) format"
+      end
+    end
+
+    # Parses underline attribute value
+    #
+    # @param value [String] Underline value
+    # @return [Symbol] Parsed underline value
+    # @raise [ArgumentError] If underline value is invalid
+    private def parse_underline_value(value)
+      case value
+      when "double"
+        :double
+      else
+        raise ArgumentError, "Invalid underline value: '#{value}'. Valid values: double"
+      end
+    end
+
+    # Validates that an attribute is a valid boolean attribute
+    #
+    # @param attribute [String] Attribute name to validate
+    # @raise [ArgumentError] If attribute is not a valid boolean attribute
+    private def validate_boolean_attribute(attribute)
+      valid_attributes = BOOLEAN_ATTRIBUTES + ["underline"]
+      return if valid_attributes.include?(attribute)
+
+      raise ArgumentError,
+        "Invalid boolean attribute: '#{attribute}'. Valid attributes: #{valid_attributes.join(", ")}"
+    end
+
+    # Creates a Style object from parsed attributes
+    #
+    # @param attributes [Hash<String, Object>] Hash of attribute names to values
+    # @return [Style] New Style object
+    private def create_style(attributes)
+      style_params = {}
+
+      attributes.each do |key, value|
+        style_params[key.to_sym] = value
+      end
+
+      Style.new(**style_params)
+    end
+  end
+end

--- a/lib/fasti/style_parser.rb
+++ b/lib/fasti/style_parser.rb
@@ -93,12 +93,7 @@ module Fasti
         next if attr.empty?
 
         case attr
-        when /\Ano-(.+)\z/
-          # Handle no- prefix (negation)
-          attribute_name = $1
-          validate_boolean_attribute(attribute_name)
-          attributes[attribute_name] = false
-        when /\A(.+)=(.+)\z/
+        when /\A(?!no-)(.+)=(.+)\z/
           # Handle key=value format
           key = $1
           value = $2
@@ -109,6 +104,11 @@ module Fasti
           end
 
           attributes[key] = parse_attribute_value(key, value)
+        when /\Ano-(.+)\z/
+          # Handle no- prefix (negation)
+          attribute_name = $1
+          validate_boolean_attribute(attribute_name)
+          attributes[attribute_name] = false
         else
           # Handle simple boolean attributes (bold, italic, etc.)
           validate_boolean_attribute(attr)

--- a/lib/fasti/style_parser.rb
+++ b/lib/fasti/style_parser.rb
@@ -86,9 +86,7 @@ module Fasti
     # @param attributes_str [String] Comma-separated attribute string
     # @return [Hash<String, Object>] Hash of attribute names to values
     private def parse_attributes(attributes_str)
-      attributes = {}
-
-      attributes_str.split(",").each do |attr|
+      attributes_str.split(",").each_with_object({}) do |attr, attributes|
         attr = attr.strip
         next if attr.empty?
 
@@ -115,8 +113,6 @@ module Fasti
           attributes[attr] = true
         end
       end
-
-      attributes
     end
 
     # Parses an attribute value based on the attribute key

--- a/spec/fasti/calendar_spec.rb
+++ b/spec/fasti/calendar_spec.rb
@@ -232,10 +232,12 @@ RSpec.describe Fasti::Calendar do
     let(:jp_calendar) { Fasti::Calendar.new(2024, 1, country: :jp) }
 
     it "returns true for US Independence Day" do
+      # July 4th - Independence Day (US holiday)
       expect(us_calendar.holiday?(4)).to be true
     end
 
     it "returns true for Japanese New Year" do
+      # January 1st - New Year's Day (Japanese national holiday)
       expect(jp_calendar.holiday?(1)).to be true
     end
 

--- a/spec/fasti/formatter_custom_styles_spec.rb
+++ b/spec/fasti/formatter_custom_styles_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Fasti::Formatter do
   ANSI_BLACK_FG = '\e\[30m'
   ANSI_RED_BOLD = '\e\[31;1m'
   ANSI_BOLD_INVERSE = '\e\[1;7m'
+  ANSI_BLACK_YELLOW_BG = '\e\[30;43m'
 
   let(:july_2024) { Fasti::Calendar.new(2024, 7, country: :us) }
 
@@ -115,7 +116,7 @@ RSpec.describe Fasti::Formatter do
       it "applies custom holiday style" do
         output = formatter.format_month(july_2024)
         # July 4 (Independence Day) should use custom holiday style
-        expect(output).to match(/\e\[30;43m\s*4#{ANSI_RESET}/)
+        expect(output).to match(/#{ANSI_BLACK_YELLOW_BG}\s*4#{ANSI_RESET}/)
       end
     end
 

--- a/spec/fasti/formatter_custom_styles_spec.rb
+++ b/spec/fasti/formatter_custom_styles_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Fasti::Formatter do
       let(:formatter) { Fasti::Formatter.new(styles:) }
 
       before do
-        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 4)) # Holiday and today
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 4)) # Independence Day (US holiday) and today
       end
 
       it "only applies specified custom styles, no defaults" do

--- a/spec/fasti/formatter_custom_styles_spec.rb
+++ b/spec/fasti/formatter_custom_styles_spec.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Fasti::Formatter do
+  # ANSI styling code constants for readable test expectations
+  ANSI_ESCAPE = '\e\['
+  ANSI_RESET = '\e\[0m'
+  ANSI_BOLD = '\e\[1m'
+  ANSI_INVERSE = '\e\[7m'
+  ANSI_RED = '\e\[31m'
+  ANSI_BLUE = '\e\[34m'
+  ANSI_YELLOW_BG = '\e\[43m'
+  ANSI_BLACK_FG = '\e\[30m'
+  ANSI_RED_BOLD = '\e\[31;1m'
+  ANSI_BOLD_INVERSE = '\e\[1;7m'
+
+  let(:july_2024) { Fasti::Calendar.new(2024, 7, country: :us) }
+
+  describe "custom styles functionality" do
+    context "with no custom styles" do
+      let(:formatter) { Fasti::Formatter.new }
+
+      before do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1))
+      end
+
+      it "uses default styling" do
+        output = formatter.format_month(july_2024)
+        # Sunday (July 7) should be bold by default
+        expect(output).to match(/#{ANSI_BOLD}\s*7#{ANSI_RESET}/)
+      end
+
+      it "applies default holiday styling" do
+        output = formatter.format_month(july_2024)
+        # July 4 (Independence Day) should be bold by default
+        expect(output).to match(/#{ANSI_BOLD}\s*4#{ANSI_RESET}/)
+      end
+
+      it "applies default today styling when today" do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 15))
+        output = formatter.format_month(july_2024)
+        # July 15 (today) should be inverse by default
+        expect(output).to match(/#{ANSI_INVERSE}\s*15#{ANSI_RESET}/)
+      end
+    end
+
+    context "with custom styles completely replacing defaults" do
+      let(:custom_styles) do
+        {
+          sunday: Fasti::Style.new(foreground: :red)
+        }
+      end
+      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+
+      before do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 4)) # Holiday and today
+      end
+
+      it "only applies specified custom styles, no defaults" do
+        output = formatter.format_month(july_2024)
+
+        # Sunday should use custom red style
+        expect(output).to match(/#{ANSI_RED}\s*7#{ANSI_RESET}/)
+
+        # Holiday (July 4) should NOT be bold (no default holiday style)
+        expect(output).not_to match(/#{ANSI_BOLD}\s*4/)
+
+        # Today (July 4) should NOT be inverse (no default today style)
+        expect(output).not_to match(/#{ANSI_INVERSE}\s*4/)
+
+        # July 4 should appear as plain text
+        expect(output).to match(/\s+4\s/)
+      end
+    end
+
+    context "with custom weekday styles" do
+      let(:custom_styles) do
+        {
+          sunday: Fasti::Style.new(foreground: :red),
+          saturday: Fasti::Style.new(foreground: :blue)
+        }
+      end
+      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+
+      before do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1))
+      end
+
+      it "applies custom Sunday style" do
+        output = formatter.format_month(july_2024)
+        # Sunday (July 7) should use custom red foreground
+        expect(output).to match(/#{ANSI_RED}\s*7#{ANSI_RESET}/)
+      end
+
+      it "applies custom Saturday style" do
+        output = formatter.format_month(july_2024)
+        # Saturday (July 6) should use custom blue foreground
+        expect(output).to match(/#{ANSI_BLUE}\s*6#{ANSI_RESET}/)
+      end
+    end
+
+    context "with custom holiday styles" do
+      let(:custom_styles) do
+        {
+          holiday: Fasti::Style.new(background: :yellow, foreground: :black)
+        }
+      end
+      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+
+      before do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1))
+      end
+
+      it "applies custom holiday style" do
+        output = formatter.format_month(july_2024)
+        # July 4 (Independence Day) should use custom holiday style
+        expect(output).to match(/\e\[30;43m\s*4#{ANSI_RESET}/)
+      end
+    end
+
+    context "with custom today styles" do
+      let(:custom_styles) do
+        {
+          today: Fasti::Style.new(bold: true, inverse: true)
+        }
+      end
+      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+
+      before do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 15))
+      end
+
+      it "applies custom today style" do
+        output = formatter.format_month(july_2024)
+        # July 15 (today) should use custom bold + inverse style
+        expect(output).to match(/#{ANSI_BOLD_INVERSE}\s*15#{ANSI_RESET}/)
+      end
+    end
+
+    context "with style composition" do
+      let(:custom_styles) do
+        {
+          sunday: Fasti::Style.new(foreground: :red, bold: true),
+          today: Fasti::Style.new(inverse: true)
+        }
+      end
+      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+
+      before do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 7)) # Sunday
+      end
+
+      it "composes styles when day matches multiple criteria" do
+        output = formatter.format_month(july_2024)
+        # July 7 is both Sunday and today, should combine both styles
+        # The exact ANSI sequence depends on style composition order
+        expect(output).to include("7")
+        expect(output).to match(/\e\[.*7.*\e\[0m/) # Should have some ANSI styling
+      end
+    end
+
+    context "with negated styles" do
+      let(:custom_styles) do
+        {
+          sunday: Fasti::Style.new(foreground: :red, bold: false),
+          holiday: Fasti::Style.new(foreground: :green, bold: false)
+        }
+      end
+      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+
+      before do
+        allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1))
+      end
+
+      it "applies styles with explicit false values" do
+        output = formatter.format_month(july_2024)
+
+        # Sunday should be red but not bold
+        expect(output).to match(/#{ANSI_RED}\s*7#{ANSI_RESET}/)
+        expect(output).not_to match(/#{ANSI_BOLD}.*7/)
+
+        # Holiday should be green but not bold
+        expect(output).to match(/\e\[32m\s*4#{ANSI_RESET}/) # Green foreground
+        expect(output).not_to match(/#{ANSI_BOLD}.*4/)
+      end
+    end
+  end
+
+  describe "integration with StyleParser" do
+    it "works with parsed styles from StyleParser" do
+      parser = Fasti::StyleParser.new
+      parsed_styles = parser.parse("sunday:foreground=red,bold holiday:background=yellow today:inverse")
+      formatter = Fasti::Formatter.new(custom_styles: parsed_styles)
+
+      allow(Date).to receive(:today).and_return(Date.new(2024, 7, 15))
+
+      output = formatter.format_month(july_2024)
+
+      # Should contain styled elements
+      expect(output).to match(/#{ANSI_RED_BOLD}\s*7#{ANSI_RESET}/) # Sunday
+      expect(output).to match(/#{ANSI_YELLOW_BG}\s*4#{ANSI_RESET}/) # Holiday
+      expect(output).to match(/#{ANSI_INVERSE}\s*15#{ANSI_RESET}/) # Today
+    end
+  end
+end

--- a/spec/fasti/formatter_custom_styles_spec.rb
+++ b/spec/fasti/formatter_custom_styles_spec.rb
@@ -46,12 +46,12 @@ RSpec.describe Fasti::Formatter do
     end
 
     context "with custom styles completely replacing defaults" do
-      let(:custom_styles) do
+      let(:styles) do
         {
           sunday: Fasti::Style.new(foreground: :red)
         }
       end
-      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+      let(:formatter) { Fasti::Formatter.new(styles:) }
 
       before do
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 4)) # Holiday and today
@@ -75,13 +75,13 @@ RSpec.describe Fasti::Formatter do
     end
 
     context "with custom weekday styles" do
-      let(:custom_styles) do
+      let(:styles) do
         {
           sunday: Fasti::Style.new(foreground: :red),
           saturday: Fasti::Style.new(foreground: :blue)
         }
       end
-      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+      let(:formatter) { Fasti::Formatter.new(styles:) }
 
       before do
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1))
@@ -101,12 +101,12 @@ RSpec.describe Fasti::Formatter do
     end
 
     context "with custom holiday styles" do
-      let(:custom_styles) do
+      let(:styles) do
         {
           holiday: Fasti::Style.new(background: :yellow, foreground: :black)
         }
       end
-      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+      let(:formatter) { Fasti::Formatter.new(styles:) }
 
       before do
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1))
@@ -120,12 +120,12 @@ RSpec.describe Fasti::Formatter do
     end
 
     context "with custom today styles" do
-      let(:custom_styles) do
+      let(:styles) do
         {
           today: Fasti::Style.new(bold: true, inverse: true)
         }
       end
-      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+      let(:formatter) { Fasti::Formatter.new(styles:) }
 
       before do
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 15))
@@ -139,13 +139,13 @@ RSpec.describe Fasti::Formatter do
     end
 
     context "with style composition" do
-      let(:custom_styles) do
+      let(:styles) do
         {
           sunday: Fasti::Style.new(foreground: :red, bold: true),
           today: Fasti::Style.new(inverse: true)
         }
       end
-      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+      let(:formatter) { Fasti::Formatter.new(styles:) }
 
       before do
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 7)) # Sunday
@@ -161,13 +161,13 @@ RSpec.describe Fasti::Formatter do
     end
 
     context "with negated styles" do
-      let(:custom_styles) do
+      let(:styles) do
         {
           sunday: Fasti::Style.new(foreground: :red, bold: false),
           holiday: Fasti::Style.new(foreground: :green, bold: false)
         }
       end
-      let(:formatter) { Fasti::Formatter.new(custom_styles:) }
+      let(:formatter) { Fasti::Formatter.new(styles:) }
 
       before do
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1))
@@ -191,7 +191,7 @@ RSpec.describe Fasti::Formatter do
     it "works with parsed styles from StyleParser" do
       parser = Fasti::StyleParser.new
       parsed_styles = parser.parse("sunday:foreground=red,bold holiday:background=yellow today:inverse")
-      formatter = Fasti::Formatter.new(custom_styles: parsed_styles)
+      formatter = Fasti::Formatter.new(styles: parsed_styles)
 
       allow(Date).to receive(:today).and_return(Date.new(2024, 7, 15))
 

--- a/spec/fasti/formatter_spec.rb
+++ b/spec/fasti/formatter_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Fasti::Formatter do
 
     describe "holiday styling" do
       before do
-        # July 4, 2024 is Independence Day (Thursday, holiday)
+        # July 4, 2024 is Independence Day (US holiday, Thursday)
         allow(Date).to receive(:today).and_return(Date.new(2024, 7, 1)) # Not today
       end
 
@@ -249,7 +249,7 @@ RSpec.describe Fasti::Formatter do
       let(:november_2023) { Fasti::Calendar.new(2023, 11, country: :us) }
 
       before do
-        # November 11, 2023 is Veterans Day (happens to be Saturday)
+        # November 11, 2023 is Veterans Day (US holiday, Saturday)
         allow(Date).to receive(:today).and_return(Date.new(2023, 11, 1)) # Not today
       end
 
@@ -310,7 +310,7 @@ RSpec.describe Fasti::Formatter do
     let(:output) { formatter.format_month(january_us) }
 
     it "applies color formatting to the output" do
-      # January 1, 2024 is New Year's Day (holiday) and a Monday
+      # January 1, 2024 is New Year's Day (US holiday) and a Monday
       # The output should contain ANSI color codes
       expect(output).to include("\e[") # ANSI escape sequence
     end

--- a/spec/fasti/style_parser_spec.rb
+++ b/spec/fasti/style_parser_spec.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Fasti::StyleParser do
+  let(:parser) { Fasti::StyleParser.new }
+
+  describe "#parse" do
+    context "with empty or nil input" do
+      it "returns empty hash for nil" do
+        expect(parser.parse(nil)).to eq({})
+      end
+
+      it "returns empty hash for empty string" do
+        expect(parser.parse("")).to eq({})
+      end
+
+      it "returns empty hash for whitespace-only string" do
+        expect(parser.parse("   ")).to eq({})
+      end
+    end
+
+    context "with simple boolean attributes" do
+      it "parses single boolean attribute" do
+        result = parser.parse("sunday:bold")
+        expect(result[:sunday]).to have_attributes(bold: true)
+      end
+
+      it "parses multiple boolean attributes" do
+        result = parser.parse("sunday:bold,italic,underline")
+        expect(result[:sunday]).to have_attributes(
+          bold: true,
+          italic: true,
+          underline: true
+        )
+      end
+
+      it "parses negated attributes" do
+        result = parser.parse("sunday:no-bold,no-italic")
+        expect(result[:sunday]).to have_attributes(
+          bold: false,
+          italic: false
+        )
+      end
+    end
+
+    context "with color attributes" do
+      it "parses foreground colors" do
+        result = parser.parse("sunday:foreground=red")
+        expect(result[:sunday]).to have_attributes(foreground: :red)
+      end
+
+      it "parses background colors" do
+        result = parser.parse("sunday:background=blue")
+        expect(result[:sunday]).to have_attributes(background: :blue)
+      end
+
+      it "parses hex colors" do
+        result = parser.parse("sunday:foreground=#FF0000")
+        expect(result[:sunday]).to have_attributes(foreground: "#FF0000")
+      end
+
+      it "parses 3-digit hex colors with #" do
+        result = parser.parse("sunday:foreground=#F00")
+        expect(result[:sunday]).to have_attributes(foreground: "#FF0000")
+      end
+
+      it "parses hex colors without #" do
+        result = parser.parse("sunday:foreground=FF0000")
+        expect(result[:sunday]).to have_attributes(foreground: "#FF0000")
+      end
+
+      it "parses 3-digit hex colors without #" do
+        result = parser.parse("sunday:foreground=F00")
+        expect(result[:sunday]).to have_attributes(foreground: "#FF0000")
+      end
+
+      it "parses both foreground and background" do
+        result = parser.parse("sunday:foreground=red,background=blue")
+        expect(result[:sunday]).to have_attributes(
+          foreground: :red,
+          background: :blue
+        )
+      end
+    end
+
+    context "with special attribute values" do
+      it "parses underline=double" do
+        result = parser.parse("sunday:underline=double")
+        expect(result[:sunday]).to have_attributes(underline: :double)
+      end
+
+      it "raises error for boolean values with equals syntax" do
+        expect { parser.parse("sunday:bold=true") }
+          .to raise_error(ArgumentError, /Boolean attributes should not use '=' syntax/)
+      end
+    end
+
+    context "with multiple targets" do
+      it "parses multiple different targets" do
+        result = parser.parse("sunday:bold monday:italic holiday:foreground=red today:inverse")
+
+        expect(result).to include(
+          sunday: have_attributes(bold: true),
+          monday: have_attributes(italic: true),
+          holiday: have_attributes(foreground: :red),
+          today: have_attributes(inverse: true)
+        )
+      end
+
+      it "handles all weekday targets" do
+        style_string = "sunday:bold monday:italic tuesday:underline wednesday:overline thursday:blink friday:hide saturday:faint"
+        result = parser.parse(style_string)
+
+        expect(result).to include(
+          sunday: have_attributes(bold: true),
+          monday: have_attributes(italic: true),
+          tuesday: have_attributes(underline: true),
+          wednesday: have_attributes(overline: true),
+          thursday: have_attributes(blink: true),
+          friday: have_attributes(hide: true),
+          saturday: have_attributes(faint: true)
+        )
+      end
+    end
+
+    context "with complex combinations" do
+      it "parses complex style combinations" do
+        style_string = "sunday:foreground=red,bold,no-underline holiday:background=yellow,foreground=black,italic today:inverse,bold"
+        result = parser.parse(style_string)
+
+        expect(result).to include(
+          sunday: have_attributes(
+            foreground: :red,
+            bold: true,
+            underline: false
+          ),
+          holiday: have_attributes(
+            background: :yellow,
+            foreground: :black,
+            italic: true
+          ),
+          today: have_attributes(
+            inverse: true,
+            bold: true
+          )
+        )
+      end
+    end
+
+    context "with whitespace handling" do
+      it "handles extra whitespace between targets" do
+        result = parser.parse("sunday:bold   monday:italic")
+
+        expect(result).to include(
+          sunday: have_attributes(bold: true),
+          monday: have_attributes(italic: true)
+        )
+      end
+
+      it "handles whitespace in attribute values" do
+        result = parser.parse("sunday:bold,italic")
+        expect(result[:sunday]).to have_attributes(bold: true, italic: true)
+      end
+    end
+
+    context "with validation errors" do
+      it "raises error for invalid target" do
+        expect { parser.parse("invalid_target:bold") }
+          .to raise_error(ArgumentError, /Invalid target: 'invalid_target'/)
+      end
+
+      it "raises error for invalid color" do
+        expect { parser.parse("sunday:foreground=invalid_color") }
+          .to raise_error(ArgumentError, /Invalid color: 'invalid_color'/)
+      end
+
+      it "raises error for invalid hex color" do
+        expect { parser.parse("sunday:foreground=#ZZZ") }
+          .to raise_error(ArgumentError, /Invalid color: '#ZZZ'/)
+      end
+
+      it "raises error for invalid boolean attribute" do
+        expect { parser.parse("sunday:invalid_attr") }
+          .to raise_error(ArgumentError, /Invalid boolean attribute: 'invalid_attr'/)
+      end
+
+      it "raises error for invalid entry format" do
+        expect { parser.parse("invalid_entry_without_colon") }
+          .to raise_error(ArgumentError, /Invalid style entry format/)
+      end
+
+      it "raises error for invalid underline value" do
+        expect { parser.parse("sunday:underline=invalid") }
+          .to raise_error(ArgumentError, /Invalid underline value: 'invalid'/)
+      end
+
+      it "raises error for boolean attribute with equals syntax" do
+        expect { parser.parse("sunday:bold=maybe") }
+          .to raise_error(ArgumentError, /Boolean attributes should not use '=' syntax/)
+      end
+    end
+  end
+
+  describe "validation behavior" do
+    it "validates targets correctly" do
+      # Valid targets should work
+      expect { parser.parse("sunday:bold") }.not_to raise_error
+      expect { parser.parse("holiday:bold") }.not_to raise_error
+      expect { parser.parse("today:bold") }.not_to raise_error
+
+      # Invalid targets should raise error
+      expect { parser.parse("invalid_target:bold") }
+        .to raise_error(ArgumentError, /Invalid target/)
+    end
+
+    it "validates colors correctly" do
+      # Valid colors should work
+      expect { parser.parse("sunday:foreground=red") }.not_to raise_error
+      expect { parser.parse("sunday:foreground=default") }.not_to raise_error
+
+      # Invalid colors should raise error
+      expect { parser.parse("sunday:foreground=invalid_color") }
+        .to raise_error(ArgumentError, /Invalid color/)
+    end
+
+    it "validates boolean attributes correctly" do
+      # Valid boolean attributes should work
+      expect { parser.parse("sunday:bold") }.not_to raise_error
+      expect { parser.parse("sunday:italic") }.not_to raise_error
+
+      # Invalid boolean attributes should raise error
+      expect { parser.parse("sunday:invalid_attr") }
+        .to raise_error(ArgumentError, /Invalid boolean attribute/)
+    end
+  end
+end

--- a/spec/fasti/style_parser_spec.rb
+++ b/spec/fasti/style_parser_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Fasti::StyleParser do
         )
       end
 
-      it "handles whitespace in attribute values" do
+      it "parses attributes without internal spaces" do
         result = parser.parse("sunday:bold,italic")
         expect(result[:sunday]).to have_attributes(bold: true, italic: true)
       end
@@ -177,6 +177,21 @@ RSpec.describe Fasti::StyleParser do
       it "raises error for boolean attribute with equals syntax" do
         expect { parser.parse("sunday:bold=maybe") }
           .to raise_error(ArgumentError, /Boolean attributes should not use '=' syntax/)
+      end
+
+      it "raises error for spaces around colon in entries" do
+        expect { parser.parse("sunday :bold") }
+          .to raise_error(ArgumentError, /Invalid style entry format/)
+        expect { parser.parse("sunday: bold") }
+          .to raise_error(ArgumentError, /Invalid style entry format/)
+      end
+
+      it "raises error for whitespace inside entries" do
+        # This directly tests parse_entry with whitespace inside
+        expect { parser.__send__(:parse_entry, "sunday:foreground =red") }
+          .to raise_error(ArgumentError, /Style entry should not contain whitespace/)
+        expect { parser.__send__(:parse_entry, "sunday:background= blue") }
+          .to raise_error(ArgumentError, /Style entry should not contain whitespace/)
       end
     end
   end

--- a/spec/fasti/style_parser_spec.rb
+++ b/spec/fasti/style_parser_spec.rb
@@ -28,19 +28,12 @@ RSpec.describe Fasti::StyleParser do
 
       it "parses multiple boolean attributes" do
         result = parser.parse("sunday:bold,italic,underline")
-        expect(result[:sunday]).to have_attributes(
-          bold: true,
-          italic: true,
-          underline: true
-        )
+        expect(result[:sunday]).to have_attributes(bold: true, italic: true, underline: true)
       end
 
       it "parses negated attributes" do
         result = parser.parse("sunday:no-bold,no-italic")
-        expect(result[:sunday]).to have_attributes(
-          bold: false,
-          italic: false
-        )
+        expect(result[:sunday]).to have_attributes(bold: false, italic: false)
       end
     end
 
@@ -77,10 +70,7 @@ RSpec.describe Fasti::StyleParser do
 
       it "parses both foreground and background" do
         result = parser.parse("sunday:foreground=red,background=blue")
-        expect(result[:sunday]).to have_attributes(
-          foreground: :red,
-          background: :blue
-        )
+        expect(result[:sunday]).to have_attributes(foreground: :red, background: :blue)
       end
     end
 
@@ -130,20 +120,9 @@ RSpec.describe Fasti::StyleParser do
         result = parser.parse(style_string)
 
         expect(result).to include(
-          sunday: have_attributes(
-            foreground: :red,
-            bold: true,
-            underline: false
-          ),
-          holiday: have_attributes(
-            background: :yellow,
-            foreground: :black,
-            italic: true
-          ),
-          today: have_attributes(
-            inverse: true,
-            bold: true
-          )
+          sunday: have_attributes(foreground: :red, bold: true, underline: false),
+          holiday: have_attributes(background: :yellow, foreground: :black, italic: true),
+          today: have_attributes(inverse: true, bold: true)
         )
       end
     end


### PR DESCRIPTION
## Summary
• Add new `--style` option to CLI for comprehensive calendar styling
• Implement `StyleParser` class with flexible syntax for styling configuration  
• Support complete customization of weekdays, holidays, and today styling

## Test plan
- [x] All existing tests pass
- [x] New comprehensive test coverage for StyleParser
- [x] Custom style integration tests with Formatter
- [x] CLI option parsing and error handling tests
- [x] RuboCop code quality checks pass

:robot: Generated with [Claude Code](https://claude.ai/code)