### PR TITLE
Add clean and clobber rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ Generate API documentation:
 bundle exec rake doc
 ```
 
+Clean temporary files:
+```bash
+bundle exec rake clean
+```
+
+Remove all generated files:
+```bash
+bundle exec rake clobber
+```
+
 Run all checks:
 ```bash
 bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
+require "rake/clean"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
@@ -15,6 +16,10 @@ begin
 rescue LoadError
   # YARD not available
 end
+
+# Clean and clobber tasks
+CLEAN.include("coverage/", ".rspec_status", ".yardoc")
+CLOBBER.include("docs/api/", "pkg/")
 
 # Load custom tasks
 Dir.glob("lib/tasks/*.rake").each {|r| import r }


### PR DESCRIPTION
## Summary
- Add clean and clobber rake tasks for development environment cleanup
- Logical separation between temporary files and final build artifacts
- Update README with cleanup commands documentation

## Features Added
- **Clean Task**: Removes temporary files and cache data
  - `coverage/` - SimpleCov coverage reports (regenerated by tests)
  - `.rspec_status` - RSpec failure tracking (regenerated by test runs)
  - `.yardoc` - YARD documentation cache (regenerated by doc generation)

- **Clobber Task**: Removes final build artifacts and distribution files  
  - `docs/api/` - Generated API documentation (final output for distribution)
  - `pkg/` - Built gem packages (release artifacts)

## Usage Commands
```bash
bundle exec rake clean    # Remove temporary files
bundle exec rake clobber  # Remove all generated files
```

## Test plan
- [x] All existing tests pass
- [x] RuboCop style checks pass with require order fix
- [x] Clean task successfully removes coverage/, .rspec_status, .yardoc
- [x] Clobber task successfully removes docs/api/, pkg/
- [x] README updated with new cleanup commands
- [x] Logical file categorization verified (cache vs. final artifacts)

:robot: Generated with [Claude Code](https://claude.ai/code)
