### PR TITLE
Refactor rake tasks into separate files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,6 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rake/clean"
-require "rspec/core/rake_task"
-
-RSpec::Core::RakeTask.new(:spec)
-
-# Documentation task
-begin
-  require "yard"
-  YARD::Rake::YardocTask.new(:doc) do |t|
-    t.files = ["lib/**/*.rb", "exe/fasti"]
-    t.options = ["--output-dir", "docs/api", "--markup", "markdown"]
-  end
-rescue LoadError
-  # YARD not available
-end
-
-# Clean and clobber tasks
-CLEAN.include("coverage/", ".rspec_status", ".yardoc")
-CLOBBER.include("docs/api/", "pkg/")
 
 # Load custom tasks
 Dir.glob("lib/tasks/*.rake").each {|r| import r }

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rake/clean"
+
+# Clean and clobber tasks
+CLEAN.include("coverage/", ".rspec_status", ".yardoc")
+CLOBBER.include("docs/api/", "pkg/")

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "yard"
+
+# Documentation task
+YARD::Rake::YardocTask.new(:doc) do |t|
+  t.files = ["lib/**/*.rb", "exe/fasti"]
+  t.options = ["--output-dir", "docs/api", "--markup", "markdown"]
+end


### PR DESCRIPTION
## Summary
- Reorganize rake tasks into individual files for better maintainability
- Simplify main Rakefile to focus on core configuration
- Remove unnecessary error handling for required development dependencies

## Changes Made

### Task Organization
- **lib/tasks/rspec.rake**: RSpec test task definition
- **lib/tasks/yard.rake**: YARD documentation generation task
- **lib/tasks/clean.rake**: Clean and clobber tasks for file cleanup

### Rakefile Simplification
- Remove all task definitions from main Rakefile
- Keep only essential bundler gem tasks and default task configuration
- Reduce file size from 28 lines to 8 lines

### Code Quality Improvements
- Remove unnecessary `begin/rescue` from YARD task (YARD is required development dependency)
- Improve separation of concerns with dedicated task files
- Better maintainability through modular organization

## File Structure
```
lib/tasks/
├── clean.rake    # Clean/clobber tasks
├── rspec.rake    # Test tasks  
├── rubocop.rake  # Linting tasks (existing)
└── yard.rake     # Documentation tasks
```

## Test Plan
- [x] All existing tests pass
- [x] RuboCop style checks pass
- [x] All rake tasks work correctly after reorganization:
  - [x] `rake spec` - Run tests with coverage
  - [x] `rake doc` - Generate API documentation  
  - [x] `rake clean` - Remove temporary files
  - [x] `rake clobber` - Remove generated files
  - [x] `rake` - Default task (spec + rubocop)
- [x] Task loading mechanism works properly

:robot: Generated with [Claude Code](https://claude.ai/code)
