### PR TITLE
:arrow_down: Add Ruby 3.2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - '3.2.9'
+          - '3.3.9'
           - '3.4.5'
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   - vendor/**/*
   - benchmark/**/*
   ExtraDetails: true
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 3.2
   UseCache: true
 inherit_mode:
   merge:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ fasti/
 
 ## Technology Stack
 
-- **Ruby**: 3.4+ (modern Ruby features)
+- **Ruby**: 3.2+ (modern Ruby features with broad compatibility)
 - **Core Dependencies**:
   - `holidays` (~> 8.0): Country-specific holiday data
   - `paint` (~> 2.0): ANSI color support

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Acknowledgments
 
-- Built with Ruby 3.4+ for modern performance and features
+- Built with Ruby 3.2+ for broad compatibility and modern features
 - Uses the excellent [holidays](https://github.com/holidays/holidays) gem for accurate holiday data
 - Color support provided by the [paint](https://github.com/janlelis/paint) gem
 - Follows XDG Base Directory Specification for configuration files

--- a/fasti.gemspec
+++ b/fasti.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "A Ruby calendar gem with multiple formats and holiday highlighting for many countries"
   spec.homepage = "https://github.com/sakuro/fasti"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.4.5"
+  spec.required_ruby_version = ">= 3.2.9"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"

--- a/lib/fasti/cli.rb
+++ b/lib/fasti/cli.rb
@@ -140,7 +140,7 @@ module Fasti
       OptionParser.new do |opts|
         # Register custom type converters
         opts.accept(Symbol) {|value| value.to_sym }
-        opts.accept(:downcase_symbol) { it.downcase.to_sym }
+        opts.accept(:downcase_symbol) {|value| value.downcase.to_sym }
         if include_help
           opts.banner = "Usage: fasti [options]"
           opts.separator ""

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
+[tools]
+ruby = "3.2.9"
+
 [env]
 _.path = ["bin", "exe"]


### PR DESCRIPTION
## Summary
- Add support for Ruby 3.2.9+ while maintaining compatibility with newer versions
- Replace Ruby 3.4-specific syntax with compatible alternatives

## Changes
- Replace `it` block parameter with explicit parameter for Ruby 3.2 compatibility
- Lower required Ruby version to 3.2.9 in gemspec  
- Configure RuboCop target Ruby version to 3.2
- Add Ruby 3.2.9 and 3.3.9 to CI matrix for multi-version testing
- Set mise.toml to Ruby 3.2.9 for development environment
- Update documentation to reflect Ruby 3.2+ requirement

## Test Plan
- [x] All existing tests pass on Ruby 3.2.9
- [x] RuboCop checks pass with Ruby 3.2 target
- [x] CI will test on Ruby 3.2.9, 3.3.9, and 3.4.5

:robot: Generated with [Claude Code](https://claude.ai/code)
