### PR TITLE
Add GitHub issue references to New Features section

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,11 @@
 # TODO
 
 ## New Features
-- [ ] Structured configuration file format using dry-configurable
-- [ ] I18n of day names, month names, and help messages (gettext?)
-- [ ] Support for multiple countries' holidays simultaneously
-- [ ] Extract Style class into independent gem
-- [ ] Configurable Julian to Gregorian calendar transition date
+- [ ] Structured configuration file format using dry-configurable ([#35](https://github.com/sakuro/fasti/issues/35))
+- [ ] I18n of day names, month names, and help messages (gettext?) ([#36](https://github.com/sakuro/fasti/issues/36))
+- [ ] Support for multiple countries' holidays simultaneously ([#37](https://github.com/sakuro/fasti/issues/37))
+- [ ] Extract Style class into independent gem ([#38](https://github.com/sakuro/fasti/issues/38))
+- [ ] Configurable Julian to Gregorian calendar transition date ([#39](https://github.com/sakuro/fasti/issues/39))
 
 ## Code Quality Improvements (Post Positional Arguments)
 - [ ] Optimize method arguments in calendar generation methods ([#28](https://github.com/sakuro/fasti/issues/28))


### PR DESCRIPTION
## Summary
Complete TODO.md migration to GitHub issue-based task management by adding issue references to all New Features items.

## Changes
- Add GitHub issue numbers and URLs to all New Features section items
- Reference issues #35-#39 for comprehensive task tracking
- Complete the full migration from static TODO items to trackable GitHub issues

## Created GitHub Issues for New Features
- **#35**: Structured configuration file format using dry-configurable
- **#36**: I18n of day names, month names, and help messages  
- **#37**: Support for multiple countries' holidays simultaneously
- **#38**: Extract Style class into independent gem
- **#39**: Configurable Julian to Gregorian calendar transition date

## Benefits
- **Complete Issue Coverage**: All TODO items now have corresponding GitHub issues
- **Enhanced Tracking**: Full project roadmap visible through GitHub issues
- **Better Organization**: Issues categorized with appropriate labels
- **Individual Management**: Each feature can be assigned, discussed, and tracked independently

## Issue Management Status
- ✅ **Code Quality Improvements**: Issues #28-#32 (completed in previous PR)
- ✅ **New Features**: Issues #35-#39 (completed in this PR)
- ✅ **Project Management**: Issue #34 (GitHub Projects migration plan)

## Test Plan
- [x] All quality checks pass (RuboCop, tests)
- [x] Coverage maintained at current level
- [x] Documentation update only - no code changes

:robot: Generated with [Claude Code](https://claude.ai/code)