### PR TITLE
Clean up TODO.md and migrate to GitHub Issues navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,4 +114,18 @@ bin/console               # Interactive console
 - **Internationalization**: Multi-country holiday support with locale detection
 - **User Experience**: Intuitive CLI with helpful defaults and error messages
 
+## Ongoing Maintenance Tasks
+
+### Code Quality
+- **Improve test coverage**: Aim for 70%+ coverage (currently 69.77%)
+- **Reduce RuboCop TODO violations**: Gradually address items in `.rubocop_todo.yml`
+- **Monitor code metrics**: Keep complexity and maintainability in check
+
+### Process
+- **Regular dependency updates**: Keep gems up-to-date for security and performance
+- **Documentation maintenance**: Ensure examples and API docs stay current
+- **Issue management**: Triage and prioritize GitHub issues regularly
+
+**Note**: Specific improvement tasks are tracked as GitHub Issues. This section covers ongoing maintenance activities.
+
 This guide serves as the primary reference for AI-assisted development on the Fasti project. Always refer to the linked documents in `.claude/` for detailed procedures and standards.

--- a/TODO.md
+++ b/TODO.md
@@ -1,32 +1,11 @@
 # TODO
 
-## New Features
-- [ ] Structured configuration file format using dry-configurable ([#35](https://github.com/sakuro/fasti/issues/35))
-- [ ] I18n of day names, month names, and help messages (gettext?) ([#36](https://github.com/sakuro/fasti/issues/36))
-- [ ] Support for multiple countries' holidays simultaneously ([#37](https://github.com/sakuro/fasti/issues/37))
-- [ ] Extract Style class into independent gem ([#38](https://github.com/sakuro/fasti/issues/38))
-- [ ] Configurable Julian to Gregorian calendar transition date ([#39](https://github.com/sakuro/fasti/issues/39))
+**Tasks were previously managed in this file, but have been migrated to GitHub Issues for better tracking and collaboration.**
 
-## Code Quality Improvements (Post Positional Arguments)
-- [ ] Optimize method arguments in calendar generation methods ([#28](https://github.com/sakuro/fasti/issues/28))
-  - Currently `generate_*_calendar` methods receive full `options` object but only use `options.country`
-  - Should pass only required `country` parameter for clearer dependencies
-- [ ] Fix Time.now consistency during command execution ([#29](https://github.com/sakuro/fasti/issues/29))
-  - Multiple `Time.now` calls can cause inconsistent results when crossing month/year boundaries
-  - Should call `Time.now` once at start and pass to all dependent methods
-- [ ] Extract Options class to separate file ([#30](https://github.com/sakuro/fasti/issues/30))
-  - Move `Options = Data.define(...)` from `lib/fasti/cli.rb` to `lib/fasti/options.rb`
-  - Better separation of concerns and clearer architecture
-- [ ] Restore coverage threshold to 70% ([#31](https://github.com/sakuro/fasti/issues/31))
-  - Currently temporarily lowered to 69.5% for positional arguments feature
-  - Add more tests to achieve proper coverage for new code
-- [ ] **URGENT: Fix time-dependent test failures** ([#32](https://github.com/sakuro/fasti/issues/32))
-  - Tests depend on current month/year (`Time.now`) which causes failures across date boundaries
-  - **Risk**: Tests will fail starting October 1st, 2025 (current date: September 1st)
-  - **Solution**: Use `timecop` gem to freeze time in tests (safer than `allow` stub which doesn't auto-restore)
-  - **Implementation**: Add `gem 'timecop', group: :test` and use `Timecop.freeze(Time.new(2024, 9, 1)) do ... end`
-  - **Affected tests**: "displays calendar for specified year (current month)" and similar time-dependent cases
+## Quick Links
+- [Open Issues](https://github.com/sakuro/fasti/issues)
+- [Current Milestone](https://github.com/sakuro/fasti/milestones)
+- [All Milestones](https://github.com/sakuro/fasti/milestones?state=closed)
+- [Project Board](https://github.com/sakuro/fasti/projects) (planned)
 
-## Maintenance
-- [ ] Improve test coverage
-- [ ] Reduce RuboCop TODO violations
+For ongoing maintenance guidelines, see the [AI Development Guide](CLAUDE.md).


### PR DESCRIPTION
## Summary
Clean up TODO.md to eliminate double management and create a maintenance-free landing page for task management.

## Changes Made

### TODO.md Cleanup
- **Removed**: Specific GitHub issue references (#28-#39) to prevent future noise
- **Added**: Historical context explaining migration from TODO.md to GitHub Issues
- **Converted**: From detailed task list to navigation landing page
- **Future-proofed**: Universal links that don't require updates

### CLAUDE.md Enhancement  
- **Added**: Ongoing Maintenance Tasks section
- **Organized**: Code quality and process maintenance activities
- **Documented**: Current coverage metrics and improvement goals

## Benefits

### Elimination of Double Management
- ✅ **Single source of truth**: GitHub Issues for all specific tasks
- ✅ **No sync burden**: TODO.md doesn't need updates when issues change
- ✅ **Clear separation**: Navigation vs. tracking responsibilities

### Maintenance-Free Design
- ✅ **Universal links**: Work regardless of issue status
- ✅ **Historical context**: Explains why TODO.md is minimal
- ✅ **Future-proof**: No outdated references to accumulate

### Improved Developer Experience
- ✅ **Clear guidance**: New contributors know where to look
- ✅ **Complete coverage**: Links to all issues, milestones, and projects
- ✅ **Maintenance guidelines**: Ongoing tasks documented in CLAUDE.md

## Test Plan
- [x] All quality checks pass (RuboCop, tests)
- [x] Coverage maintained at current level  
- [x] Documentation update only - no code changes
- [x] Links verified to work correctly

:robot: Generated with [Claude Code](https://claude.ai/code)