### PR TITLE
Fix time-dependent test failures with timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 group :test do
   gem "rspec", "~> 3.0" # Testing framework
   gem "simplecov", "~> 0.22", require: false # Code coverage measurement
+  gem "timecop", "~> 0.9" # Time mocking for time-dependent tests
 end
 
 group :development, :test do

--- a/spec/fasti/cli_spec.rb
+++ b/spec/fasti/cli_spec.rb
@@ -3,9 +3,17 @@
 require "pathname"
 require "spec_helper"
 require "tempfile"
+require "timecop"
 
 RSpec.describe Fasti::CLI do
   let(:cli) { Fasti::CLI.new }
+
+  # Fix time-dependent tests by freezing time to September 1, 2024
+  around do |example|
+    Timecop.freeze(Time.new(2024, 9, 1)) do
+      example.run
+    end
+  end
 
   describe "#run" do
     # Isolate each test from the user's actual config file (~/.config/fastirc)


### PR DESCRIPTION
## Summary
- Add timecop gem dependency for reliable time mocking in tests
- Freeze time to September 1, 2024 across all CLI tests to prevent date-dependent failures
- Resolve critical issue where tests would fail starting October 1st due to hardcoded "September 2024" expectations

## Key Changes

### Timecop Integration
- **Add timecop dependency**: Added timecop gem (~> 0.9) to test group in Gemfile
- **Global time freeze**: Implemented `around` hook to freeze time at September 1, 2024 for all CLI tests
- **Preserve test semantics**: Keep `current_year = Time.now.year` pattern - now returns consistent 2024 value

### Problem Solved
**Before**: Tests with hardcoded expectations like:
```ruby
expect(result.out).to include("September 2024")  # Would fail in October!
```

**After**: Time frozen to September 1, 2024 ensures:
```ruby
current_year = Time.now.year  # Always returns 2024
expect(output).to include("June #{current_year}")  # Always "June 2024"
```

## Technical Details

- **Time freeze scope**: Applied at RSpec.describe level to cover all CLI tests
- **Environment isolation**: Works alongside existing XDG_CONFIG_HOME isolation
- **Backward compatibility**: All existing test expectations remain valid
- **Future-proof**: Easy to adjust frozen date if needed

## Test Plan
- [x] All 35 CLI tests pass with frozen time
- [x] Verified `current_year` variables return 2024 consistently
- [x] Confirmed hardcoded "September 2024" expectations work correctly
- [x] No changes needed to test logic or assertions

## Impact
- **Reliability**: ↑ Tests will not fail when calendar months change
- **Maintainability**: ↑ Predictable test environment regardless of execution date
- **CI Stability**: ↑ Prevents unexpected failures in production CI pipeline

Closes #32

:robot: Generated with [Claude Code](https://claude.ai/code)