### PR TITLE
Refactor formatter tests to remove default style assumptions

### DIFF
--- a/spec/fasti/formatter_spec.rb
+++ b/spec/fasti/formatter_spec.rb
@@ -164,33 +164,6 @@ RSpec.describe Fasti::Formatter do
         expect(first_week).to match(/^\s+/)
       end
     end
-
-    context "when formatting holiday and weekend" do
-      let(:january_calendar) { Fasti::Calendar.new(2024, 1, country: :us) }
-
-      it "applies special formatting to holidays and weekends" do
-        # This is hard to test directly due to ANSI codes, but we can verify
-        # the output contains Paint formatting
-        output = formatter.format_month(january_calendar)
-        # The output should contain ANSI escape sequences for bold styling
-        # Should contain some ANSI formatting (holidays/Sundays have bold)
-        expect(output).to contain_styled(:bold, /.+/, reset: false) # Should have bold for holidays/Sundays
-      end
-    end
-
-    context "when highlighting today" do
-      before do
-        # Mock Date.today to control "today" for testing
-        allow(Date).to receive(:today).and_return(Date.new(2024, 6, 15))
-      end
-
-      it "highlights today's date" do
-        output = formatter.format_month(calendar)
-        # Should contain ANSI codes for inverse formatting
-        # June 15, 2024 is a Saturday (no special styling) + inverse
-        expect(output).to contain_styled(:inverse, /\s*15/)
-      end
-    end
   end
 
   describe "day styling behavior" do


### PR DESCRIPTION
## Summary

Remove legacy default style tests from `formatter_spec.rb` that are inconsistent with the current architecture where no default styles exist.

## Background

After implementing dry-configurable (#50), the application no longer has default styles built into the core. All styles are now explicitly configured by users. However, some tests in `formatter_spec.rb` still assumed default styling behavior.

## Changes

- Remove "when formatting holiday and weekend" test context that assumed default bold styling
- Remove "when highlighting today" test context that assumed default inverse styling  
- All style-related functionality remains covered by `formatter_custom_styles_spec.rb`
- Focus `formatter_spec.rb` on core formatting functionality (layout, headers, structure)

## Test Results

- Test count: 193 → 191 examples, 0 failures
- Line Coverage: 97.78% (maintained)
- Branch Coverage: 90.0% (maintained)

## Verification

The removed tests were testing default behavior that no longer exists. All style functionality is properly covered by dedicated style tests in `formatter_custom_styles_spec.rb`:

- Custom holiday styling (lines 87-91)
- Custom today styling (lines 106-110)  
- Custom weekend styling (lines 62-72)
- Style composition (lines 113+)

Closes #51

:robot: Generated with [Claude Code](https://claude.ai/code)