### PR TITLE
Add format shortcut options --month/-m, --quarter/-q, --year/-y

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,25 @@ fasti 6 2024
 **Month View** (default):
 ```bash
 fasti 6 2024 --format month
+# Or using shortcuts:
+fasti 6 2024 --month
+fasti 6 2024 -m
 ```
 
 **Quarter View** (3 months side by side):
 ```bash
 fasti 6 2024 --format quarter
+# Or using shortcuts:
+fasti 6 2024 --quarter
+fasti 6 2024 -q
 ```
 
 **Year View** (all 12 months):
 ```bash
 fasti 2024 --format year
+# Or using shortcuts:
+fasti 2024 --year
+fasti 2024 -y
 ```
 
 ### Week Start Configuration
@@ -98,8 +107,13 @@ Arguments:
   month  Month (1-12, optional)
   year   Year (optional)
 
-Calendar display options:
+Format options:
   -f, --format FORMAT           Output format (month, quarter, year)
+  -m, --month                   Display month format (equivalent to --format month)
+  -q, --quarter                 Display quarter format (equivalent to --format quarter)
+  -y, --year                    Display year format (equivalent to --format year)
+
+Calendar display options:
   -w, --start-of-week WEEKDAY   Week start day (any day of the week)
   -c, --country COUNTRY         Country code for holidays (e.g., JP, US, GB, DE)
   -s, --style STYLE             Custom styling (e.g., "sunday:bold holiday:foreground=red today:inverse")

--- a/lib/fasti/cli.rb
+++ b/lib/fasti/cli.rb
@@ -191,7 +191,7 @@ module Fasti
           opts.separator "  month  Month (1-12, optional)"
           opts.separator "  year   Year (optional)"
           opts.separator ""
-          opts.separator "Calendar display options:"
+          opts.separator "Format options:"
         end
 
         opts.on(
@@ -202,6 +202,35 @@ module Fasti
           "Output format (month, quarter, year)"
         ) do |format|
           options[:format] = format
+        end
+
+        opts.on(
+          "-m",
+          "--month",
+          "Display month format (equivalent to --format month)"
+        ) do
+          options[:format] = :month
+        end
+
+        opts.on(
+          "-q",
+          "--quarter",
+          "Display quarter format (equivalent to --format quarter)"
+        ) do
+          options[:format] = :quarter
+        end
+
+        opts.on(
+          "-y",
+          "--year",
+          "Display year format (equivalent to --format year)"
+        ) do
+          options[:format] = :year
+        end
+
+        if include_help
+          opts.separator ""
+          opts.separator "Calendar display options:"
         end
 
         opts.on(

--- a/spec/fasti/cli_spec.rb
+++ b/spec/fasti/cli_spec.rb
@@ -40,8 +40,13 @@ RSpec.describe Fasti::CLI do
             month  Month (1-12, optional)
             year   Year (optional)
 
-          Calendar display options:
+          Format options:
               -f, --format FORMAT              Output format (month, quarter, year)
+              -m, --month                      Display month format (equivalent to --format month)
+              -q, --quarter                    Display quarter format (equivalent to --format quarter)
+              -y, --year                       Display year format (equivalent to --format year)
+
+          Calendar display options:
               -w, --start-of-week WEEKDAY      Week start day (sunday, monday, tuesday, wednesday, thursday, friday, saturday)
               -c, --country COUNTRY            Country code for holidays (e.g., JP, US, GB, DE)
               -s, --style STYLE                Custom styling (e.g., "sunday:bold holiday:foreground=red today:inverse")
@@ -129,6 +134,58 @@ RSpec.describe Fasti::CLI do
       it "displays calendar with friday start" do
         expect { cli.run(%w[6 2024 --start-of-week friday --country US]) }
           .to output(include("June 2024", "Fr Sa Su Mo Tu We Th")).to_stdout
+      end
+    end
+
+    context "with format shortcut options" do
+      it "displays month format using --month" do
+        expect { cli.run(%w[6 2024 --month --country US]) }
+          .to output(include("June 2024", "Su Mo Tu We Th Fr Sa")).to_stdout
+      end
+
+      it "displays month format using -m" do
+        expect { cli.run(%w[6 2024 -m --country US]) }
+          .to output(include("June 2024", "Su Mo Tu We Th Fr Sa")).to_stdout
+      end
+
+      it "displays quarter format using --quarter" do
+        expect { cli.run(%w[6 2024 --quarter --country US]) }
+          .to output(include("May 2024", "June 2024", "July 2024")).to_stdout
+      end
+
+      it "displays quarter format using -q" do
+        expect { cli.run(%w[6 2024 -q --country US]) }
+          .to output(include("May 2024", "June 2024", "July 2024")).to_stdout
+      end
+
+      it "displays year format using --year" do
+        expect { cli.run(%w[2024 --year --country US]) }
+          .to output(include("2024", "January 2024", "December 2024")).to_stdout
+      end
+
+      it "displays year format using -y" do
+        expect { cli.run(%w[2024 -y --country US]) }
+          .to output(include("2024", "January 2024", "December 2024")).to_stdout
+      end
+
+      it "uses last specified option when multiple shortcuts are provided" do
+        expect { cli.run(%w[6 2024 --month --quarter --year --country US]) }
+          .to output(include("2024", "January 2024", "December 2024")).to_stdout
+      end
+
+      it "uses last specified option when mixing shortcuts with --format" do
+        expect { cli.run(%w[6 2024 --format month --year --country US]) }
+          .to output(include("2024", "January 2024", "December 2024")).to_stdout
+      end
+
+      it "uses last specified option when --format comes after shortcuts" do
+        expect { cli.run(%w[6 2024 --year --format quarter --country US]) }
+          .to output(include("May 2024", "June 2024", "July 2024")).to_stdout
+      end
+
+      it "uses last specified option with short flags" do
+        expect { cli.run(%w[6 2024 -m -q -y --country US]) }
+          .to output(include("2024", "January 2024", "December 2024")).to_stdout
       end
     end
 


### PR DESCRIPTION
## Summary

Add convenient shortcut options for the three `--format` values with intuitive conflict resolution that follows CLI conventions.

## New Options

- `--month` / `-m` → equivalent to `--format month`
- `--quarter` / `-q` → equivalent to `--format quarter`  
- `--year` / `-y` → equivalent to `--format year`

## Key Features

**Intuitive Shortcuts**: Shorter, more memorable commands
```bash
# Before (verbose)
fasti --format quarter
fasti --format year

# After (concise)
fasti --quarter  # or -q
fasti --year     # or -y
```

**Smart Conflict Resolution**: Last specified option wins
```bash
fasti --month --quarter --year    # Uses year format
fasti --format month -y           # Uses year format
fasti -m -q                       # Uses quarter format
```

**Organized Help**: Clear separation of format vs display options
```
Format options:
  -f, --format FORMAT     Output format (month, quarter, year)
  -m, --month            Display month format
  -q, --quarter          Display quarter format
  -y, --year             Display year format

Calendar display options:
  -w, --start-of-week    Week start day
  -c, --country          Country code for holidays
  -s, --style            Custom styling
```

## Implementation Details

- **No Breaking Changes**: All existing functionality preserved
- **Natural Precedence**: Options overwrite naturally (last wins)
- **Help Organization**: Separated "Format options" from "Calendar display options"
- **Comprehensive Tests**: 10 new tests covering all shortcuts and conflict scenarios

## Usage Examples

```bash
# Basic shortcuts
fasti 6 2024 --month      # June 2024, month view
fasti 6 2024 --quarter    # May-July 2024, quarter view
fasti 2024 --year         # Full 2024, year view

# Short flags
fasti -m                  # Current month
fasti -q                  # Current quarter
fasti -y                  # Current year

# Mixed usage (last option wins)
fasti --format month -y   # Year view (last specified)
fasti -m --quarter        # Quarter view (last specified)
```

## Files Changed

- **lib/fasti/cli.rb**: Add shortcut options and reorganize help sections
- **spec/fasti/cli_spec.rb**: Add comprehensive test coverage for shortcuts and conflicts  
- **README.md**: Update examples and documentation

## Test Results

- ✅ 201 examples, 0 failures
- ✅ Line Coverage: 97.82% (494/505)
- ✅ Branch Coverage: 89.51% (145/162)
- ✅ 0 RuboCop offenses
- ✅ 10 new tests for format shortcuts and conflict resolution

## Benefits

- **User Experience**: Faster, more intuitive commands
- **Backward Compatibility**: Original `--format` option continues to work
- **CLI Conventions**: Follows standard practices for option shortcuts
- **Clear Documentation**: Well-organized help and examples

Closes #48

:robot: Generated with [Claude Code](https://claude.ai/code)