### PR TITLE
:wrench: Improve CLI error handling testability

### DIFF
--- a/lib/fasti/cli.rb
+++ b/lib/fasti/cli.rb
@@ -78,8 +78,7 @@ module Fasti
         generate_calendar(month, year, options)
       end
     rescue => e
-      puts "Error: #{e.message}"
-      exit 1
+      handle_error(e)
     end
 
     # Parses all command line arguments (positional + options).
@@ -498,6 +497,17 @@ module Fasti
       end
 
       result
+    end
+
+    # Handles errors that occur during CLI execution.
+    #
+    # This method is extracted to improve testability by allowing
+    # error handling to be mocked or stubbed during testing.
+    #
+    # @param error [Exception] The error that occurred
+    private def handle_error(error)
+      puts "Error: #{error.message}"
+      exit 1
     end
   end
 end


### PR DESCRIPTION
## Summary
- Extract CLI error handling into separate method for improved testability
- Allow mocking of error handling during tests to prevent test process termination
- Maintain backward compatibility with existing production error behavior

## Changes
- Extract handle_error method from inline rescue block in CLI#run
- Add comprehensive test coverage for error handling isolation scenarios
- Support mocking handle_error to avoid SystemExit during testing

## Test plan
- [x] All existing tests continue to pass (205 examples, 0 failures)
- [x] New tests verify error handling can be mocked safely
- [x] New tests verify original error behavior is preserved when not mocked
- [x] RuboCop violations resolved (trailing whitespace, use of __send__)

Fixes #49

Co-Authored-By: Claude <noreply@anthropic.com>
