### PR TITLE
Remove --show-gaps option to avoid confusion in calendar transition display

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,7 +33,6 @@ Metrics/ClassLength:
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/CyclomaticComplexity:
   Exclude:
-    - 'lib/fasti/calendar.rb'
     - 'lib/fasti/formatter.rb'
     - 'lib/fasti/style.rb'
 
@@ -49,15 +48,9 @@ Metrics/MethodLength:
     - 'lib/fasti/style_parser.rb'
     - 'spec/support/ansi_matchers.rb'
 
-# Configuration parameters: Max, CountKeywordArgs, MaxOptionalParameters.
-Metrics/ParameterLists:
-  Exclude:
-    - 'lib/fasti/cli.rb'
-
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/PerceivedComplexity:
   Exclude:
-    - 'lib/fasti/calendar.rb'
     - 'lib/fasti/formatter.rb'
     - 'lib/fasti/style.rb'
 

--- a/README.md
+++ b/README.md
@@ -104,32 +104,27 @@ Fasti automatically detects your country from environment variables (`LC_ALL`, `
 For historical dates, Fasti supports country-specific Julian to Gregorian calendar transitions with proper gap handling:
 
 ```bash
-# Show October 1582 (Italian transition) - compressed gaps (default)
+# Show October 1582 (Italian transition) - compressed display
 fasti 10 1582 --country IT
 
-# Show gaps historically - October 5-14, 1582 never existed in Italy
-fasti 10 1582 --country IT --show-gaps
-
 # British transition - September 3-13, 1752 never existed in Britain
-fasti 9 1752 --country GB --show-gaps
+fasti 9 1752 --country GB
 
 # Asian countries transitioned from lunisolar calendars
 # Japan transitioned in 1873 (Meiji era)
-fasti 12 1872 --country JP --show-gaps
+fasti 12 1872 --country JP
 
 # Korea transitioned in 1896 (Korean Empire era)
-fasti 12 1895 --country KR --show-gaps
+fasti 12 1895 --country KR
 
 # France had different transition date than Italy
-fasti 12 1582 --country FR --show-gaps
+fasti 12 1582 --country FR
 
 # Sweden's complex transition in 1753
-fasti 3 1753 --country SE --show-gaps
+fasti 3 1753 --country SE
 ```
 
-**Gap Display Options:**
-- `--show-gaps`: Show calendar transition gaps as empty spaces
-- `--no-show-gaps` (default): Compress gaps like UNIX `cal` command for continuous display
+Calendar transitions are displayed in compressed format (like UNIX `cal` command) for continuous display without confusing gaps.
 
 Supported countries with calendar transition dates:
 
@@ -170,7 +165,6 @@ Calendar display options:
   -w, --start-of-week WEEKDAY   Week start day (any day of the week)
   -c, --country COUNTRY         Country code for holidays (e.g., JP, US, GB, DE)
   -s, --style STYLE             Custom styling (e.g., "sunday:bold holiday:foreground=red today:inverse")
-      --[no-]show-gaps          Show calendar transition gaps as empty space (default: compress like UNIX cal)
 
 Other options:
   -v, --version                 Show version
@@ -208,7 +202,6 @@ Fasti.configure do |config|
   config.format = :quarter
   config.start_of_week = :monday
   config.country = :US
-  config.show_gaps = false  # Default: compress calendar transition gaps
   # Custom styling (optional)
   config.style = {
     sunday: { bold: true },
@@ -350,11 +343,11 @@ Fasti properly handles historical calendar transitions with country-specific tra
 Historical transition periods display correctly with proper gap handling:
 
 ```bash
-# Italian transition works correctly - shows gaps or compressed display
-fasti 10 1582 --country IT --show-gaps
+# Italian transition works correctly - shows compressed display
+fasti 10 1582 --country IT
 
 # Asian countries show transitions from lunisolar calendars
-fasti 12 1872 --country JP --show-gaps
+fasti 12 1872 --country JP
 ```
 
 **Note**: Standard UNIX calendar tools like `cal` and `gcal` correctly handle these historical transitions by appropriately skipping non-existent dates during calendar reforms.

--- a/lib/fasti/cli.rb
+++ b/lib/fasti/cli.rb
@@ -6,7 +6,7 @@ require "pathname"
 
 module Fasti
   # Immutable data structure for CLI options
-  Options = Data.define(:format, :start_of_week, :country, :style, :show_gaps)
+  Options = Data.define(:format, :start_of_week, :country, :style)
 
   # Command-line interface for the fasti calendar application.
   #
@@ -58,7 +58,7 @@ module Fasti
     private_constant :NON_COUNTRY_LOCALES
 
     # General configuration attributes (non-style attributes)
-    GENERAL_ATTRIBUTES = %i[format start_of_week country show_gaps].freeze
+    GENERAL_ATTRIBUTES = %i[format start_of_week country].freeze
     private_constant :GENERAL_ATTRIBUTES
 
     # Runs the CLI with the specified arguments.
@@ -130,8 +130,7 @@ module Fasti
         format: :month,
         start_of_week: :sunday,
         country: detect_country_from_environment,
-        style: nil,
-        show_gaps: false # Default: compress gaps like UNIX cal
+        style: nil
       }
     end
 
@@ -262,13 +261,6 @@ module Fasti
           options[:style] = StyleParser.new.parse(style)
         end
 
-        opts.on(
-          "--[no-]show-gaps",
-          "Show calendar transition gaps as empty space (default: compress like UNIX cal)"
-        ) do |show_gaps|
-          options[:show_gaps] = show_gaps
-        end
-
         if include_help
           opts.separator ""
           opts.separator "Other options:"
@@ -295,15 +287,13 @@ module Fasti
       formatter = Formatter.new(styles:)
       start_of_week = options.start_of_week
       country = options.country
-      show_gaps = options.show_gaps
-
       output = case options.format
                when :month
-                 generate_month_calendar(month, year, country, formatter, start_of_week, show_gaps)
+                 generate_month_calendar(month, year, country, formatter, start_of_week)
                when :quarter
-                 generate_quarter_calendar(month, year, country, formatter, start_of_week, show_gaps)
+                 generate_quarter_calendar(month, year, country, formatter, start_of_week)
                when :year
-                 generate_year_calendar(month, year, country, formatter, start_of_week, show_gaps)
+                 generate_year_calendar(month, year, country, formatter, start_of_week)
                else
                  raise ArgumentError, "Unknown format: #{options.format}"
                end
@@ -317,13 +307,12 @@ module Fasti
     # @param formatter [Formatter] Calendar formatter
     # @param start_of_week [Symbol] Week start preference
     # @return [String] Formatted calendar
-    private def generate_month_calendar(month, year, country, formatter, start_of_week, show_gaps)
+    private def generate_month_calendar(month, year, country, formatter, start_of_week)
       calendar = Calendar.new(
         year,
         month,
         start_of_week:,
-        country:,
-        show_gaps:
+        country:
       )
       formatter.format_month(calendar)
     end
@@ -334,7 +323,7 @@ module Fasti
     # @param formatter [Formatter] Calendar formatter
     # @param start_of_week [Symbol] Week start preference
     # @return [String] Formatted quarter calendar
-    private def generate_quarter_calendar(month, year, country, formatter, start_of_week, show_gaps)
+    private def generate_quarter_calendar(month, year, country, formatter, start_of_week)
       base_month = month
 
       months = [(base_month - 1), base_month, (base_month + 1)].map {|m|
@@ -348,7 +337,7 @@ module Fasti
       }
 
       calendars = months.map {|y, m|
-        Calendar.new(y, m, start_of_week:, country:, show_gaps:)
+        Calendar.new(y, m, start_of_week:, country:)
       }
 
       formatter.format_quarter(calendars)
@@ -360,12 +349,11 @@ module Fasti
     # @param formatter [Formatter] Calendar formatter
     # @param start_of_week [Symbol] Week start preference
     # @return [String] Formatted year calendar
-    private def generate_year_calendar(_month, year, country, formatter, start_of_week, show_gaps)
+    private def generate_year_calendar(_month, year, country, formatter, start_of_week)
       formatter.format_year(
         year,
         country:,
-        start_of_week:,
-        show_gaps:
+        start_of_week:
       )
     end
 

--- a/lib/fasti/config.rb
+++ b/lib/fasti/config.rb
@@ -36,9 +36,6 @@ module Fasti
     # Country code for holiday detection
     setting :country, default: :us, constructor: Types::Country
 
-    # Show calendar transition gaps
-    setting :show_gaps, default: false, constructor: Types::Params::Bool
-
     # Style configuration
     # Accepts a hash mapping style targets to their attributes
     # @param value [Hash<Symbol|String, Hash>] Style configuration hash
@@ -92,7 +89,6 @@ module Fasti
         config.format = :month
         config.start_of_week = :sunday
         config.country = :us
-        config.show_gaps = false
         config.style = nil
       end
     end

--- a/lib/fasti/formatter.rb
+++ b/lib/fasti/formatter.rb
@@ -129,13 +129,12 @@ module Fasti
     # @param year [Integer] The year to display
     # @param start_of_week [Symbol] Week start preference (:sunday or :monday)
     # @param country [String] Country code for holiday context
-    # @param show_gaps [Boolean] Whether to show calendar transition gaps
     # @return [String] Formatted year view string
     #
     # @example Full year display
-    #   formatter.format_year(2024, start_of_week: :sunday, country: :jp, show_gaps: false)
+    #   formatter.format_year(2024, start_of_week: :sunday, country: :jp)
     #   # Displays all 12 months in 4 rows of 3 months each
-    def format_year(year, country:, start_of_week: :sunday, show_gaps: false)
+    def format_year(year, country:, start_of_week: :sunday)
       output = []
 
       # Year header
@@ -145,7 +144,7 @@ module Fasti
       # Process 4 quarters (3 months each)
       quarters = []
       (1..12).each_slice(3) do |months|
-        calendars = months.map {|month| Calendar.new(year, month, start_of_week:, country:, show_gaps:) }
+        calendars = months.map {|month| Calendar.new(year, month, start_of_week:, country:) }
         quarters << format_quarter(calendars)
       end
 

--- a/spec/fasti/calendar_spec.rb
+++ b/spec/fasti/calendar_spec.rb
@@ -371,9 +371,8 @@ RSpec.describe Fasti::Calendar do
 
     context "calendar grid generation with gaps" do
       let(:italian_calendar) { Fasti::Calendar.new(1582, 10, country: :it) }
-      let(:italian_calendar_show_gaps) { Fasti::Calendar.new(1582, 10, country: :it, show_gaps: true) }
 
-      it "generates calendar grid correctly despite transition gaps (compressed mode - default)" do
+      it "generates calendar grid correctly despite transition gaps (compressed mode)" do
         grid = italian_calendar.calendar_grid
         expect(grid).to be_an(Array)
         expect(grid.length).to be > 0
@@ -388,48 +387,8 @@ RSpec.describe Fasti::Calendar do
         expect(flat_days.length).to eq(21)
       end
 
-      it "generates calendar grid with gaps shown as empty spaces (show_gaps: true)" do
-        grid = italian_calendar_show_gaps.calendar_grid
-        expect(grid).to be_an(Array)
-        expect(grid.length).to be > 0
-
-        # Grid should still only contain valid days when compacted
-        flat_days = grid.flatten
-        flat_days.compact!
-        expect(flat_days).to include(1, 2, 3, 4, 15, 16) # Valid days before and after gap
-        expect(flat_days).not_to include(5, 6, 7, 8, 9, 10, 11, 12, 13, 14) # Gap days
-
-        # Should have 21 valid days (31 total - 10 gap days)
-        expect(flat_days.length).to eq(21)
-
-        # But the grid should have more nil entries to show the gaps
-        all_entries = grid.flatten
-        nil_count = all_entries.count(nil)
-        expect(nil_count).to be > 10 # Should have extra nils for the gap
-      end
-
-      it "show_gaps mode maintains proper weekday alignment" do
-        grid = italian_calendar_show_gaps.calendar_grid
-
-        # Each week should still have exactly 7 entries
-        grid.each do |week|
-          expect(week.length).to eq(7)
-        end
-
-        # Check that Oct 15, 1582 (first day after gap) is properly aligned
-        # Oct 1 was a Friday, so Oct 15 should be a Friday too (JDN continuity)
-        flat_days = grid.flatten
-        oct_15_index = flat_days.index(15)
-        expect(oct_15_index).not_to be_nil
-
-        # Oct 15 should be in the same weekday position as it would be in compressed mode
-        oct_15_week_pos = oct_15_index % 7
-        expect(oct_15_week_pos).to eq(5) # Friday position (0=Sunday, 1=Monday, ..., 5=Friday)
-      end
-
       it "handles month_year_header for historical dates" do
         expect(italian_calendar.month_year_header).to eq("October 1582")
-        expect(italian_calendar_show_gaps.month_year_header).to eq("October 1582")
       end
     end
   end

--- a/spec/fasti/cli_spec.rb
+++ b/spec/fasti/cli_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe Fasti::CLI do
               -w, --start-of-week WEEKDAY      Week start day (sunday, monday, tuesday, wednesday, thursday, friday, saturday)
               -c, --country COUNTRY            Country code for holidays (e.g., JP, US, GB, DE)
               -s, --style STYLE                Custom styling (e.g., "sunday:bold holiday:foreground=red today:inverse")
-                  --[no-]show-gaps             Show calendar transition gaps as empty space (default: compress like UNIX cal)
 
           Other options:
               -v, --version                    Show version

--- a/spec/fasti/config_spec.rb
+++ b/spec/fasti/config_spec.rb
@@ -158,7 +158,6 @@ RSpec.describe Fasti::Config do
         format: :quarter,
         start_of_week: :sunday, # default
         country: :jp,
-        show_gaps: false, # default
         style: {sunday: Fasti::Style.new(bold: true)}
       })
     end


### PR DESCRIPTION
## Summary

Removes the `--show-gaps` option to eliminate confusion in calendar transition display. The option showed misleading gaps that made it appear as if more days were missing than actually were.

## Problem Solved

- **Issue #57**: Italy's October 1582 transition showed 14 blank spaces in week layout even though only 10 dates (Oct 5-14) were missing
- Visual confusion between actual missing days vs. displayed blank spaces
- Unnecessary complexity with dual display modes

## Changes Made

### Code Simplification
- :white_check_mark: Remove `--show-gaps` / `--no-show-gaps` CLI options
- :white_check_mark: Remove `show_gaps` parameter from Calendar, Config, and Formatter classes
- :white_check_mark: Delete `calendar_grid_with_gaps` method and inline `calendar_grid_continuous`
- :white_check_mark: Always use compressed display (UNIX `cal` command style)

### Documentation & Tests
- :white_check_mark: Update README.md to remove `--show-gaps` references
- :white_check_mark: Update CLI help message
- :white_check_mark: Remove/update related tests
- :white_check_mark: Regenerate `.rubocop_todo.yml`

## Impact

### Before (Confusing)
```
October 1582    
Mo Tu We Th Fr Sa Su
 1  2  3  4         
                    
            15 16 17
```
*Shows 14+ blank spaces, confusing users about actual missing days*

### After (Clear)
```
October 1582    
Mo Tu We Th Fr Sa Su
 1  2  3  4 15 16 17
18 19 20 21 22 23 24
25 26 27 28 29 30 31
```
*Clean, compressed display like UNIX `cal` - shows exactly what exists*

## Quality Assurance

- :white_check_mark: **242 tests pass** (0 failures)
- :white_check_mark: **96.46% code coverage** maintained
- :white_check_mark: **RuboCop violations: 0**
- :white_check_mark: **Code reduced by 205 lines** (57 added, 205 removed)
- :white_check_mark: All pre-push hooks pass

## Test Plan

- [x] Historical calendar transitions display correctly (Italy 1582, Britain 1752, etc.)
- [x] All existing functionality preserved
- [x] CLI help shows correct options
- [x] Configuration file works without show_gaps setting
- [x] All display formats (month/quarter/year) work correctly

Fixes #57

:robot: Generated with [Claude Code](https://claude.ai/code)