### PR TITLE
Configure YARD to use redcarpet as markdown provider

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,5 @@
 --markup markdown
+--markup-provider redcarpet
 --output-dir docs/api
 --readme README.md
 --files CHANGELOG.md,LICENSE.txt

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ group :development do
   gem "rubocop-performance" # RuboCop plugin for performance
   gem "rubocop-rake" # RuboCop plugin for Rake tasks
   gem "rubocop-rspec" # RuboCop plugin for RSpec
+
+  gem "redcarpet" # Markdown processor for YARD
   gem "yard", github: "lsegal/yard", ref: "5b93b3a" # Documentation generation tool (Data class support)
 end
 

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -3,7 +3,4 @@
 require "yard"
 
 # Documentation task
-YARD::Rake::YardocTask.new(:doc) do |t|
-  t.files = ["lib/**/*.rb", "exe/fasti"]
-  t.options = ["--output-dir", "docs/api", "--markup", "markdown"]
-end
+YARD::Rake::YardocTask.new(:doc)


### PR DESCRIPTION
## Summary
- Configure YARD to use redcarpet as the markdown provider
- Centralize YARD configuration in `.yardopts` file
- Simplify rake task to use `.yardopts` settings

## Changes
- Add `--markup-provider redcarpet` to `.yardopts`
- Add `redcarpet` gem to development dependencies
- Group redcarpet with yard in Gemfile for better organization
- Simplify `yard.rake` task to automatically use `.yardopts` configuration

## Benefits
- Better markdown rendering with redcarpet features
- Unified configuration between `rake doc` and `yard doc` commands
- Reduced configuration duplication
- Cleaner rake task definition

## Test plan
- [x] Verify `bundle exec yard doc` works with redcarpet
- [x] Verify `bundle exec rake doc` uses same configuration
- [x] All tests pass
- [x] RuboCop checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)