### PR TITLE
:lipstick: Add status badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # :spiral_calendar: Fasti
 
+[![Gem Version](https://badge.fury.io/rb/fasti.svg)](https://badge.fury.io/rb/fasti)
+[![CI](https://github.com/sakuro/fasti/workflows/CI/badge.svg)](https://github.com/sakuro/fasti/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Gem Downloads](https://img.shields.io/gem/dt/fasti.svg)](https://rubygems.org/gems/fasti)
+[![Depfu](https://badges.depfu.com/badges/57045bfa6f47bc651aa055b9bd4e5387/overview.svg)](https://depfu.com/github/sakuro/fasti)
+
 A flexible calendar application with multi-country holiday support, written in Ruby. Fasti provides beautiful, colorful calendar displays with support for multiple output formats, configurable week start days, and country-specific holiday highlighting.
 
 ## Features


### PR DESCRIPTION
## Summary
Add comprehensive status badges to the README header for improved project visibility and quick status overview.

### Added Badges
- **📦 Gem Version**: Shows current version available on RubyGems
- **✅ CI Status**: Displays GitHub Actions build status from CI workflow
- **📄 License**: Indicates MIT license for clear licensing information
- **📊 Downloads**: Shows total gem download statistics from RubyGems
- **🔄 Depfu**: Displays dependency update status for maintenance visibility

### Visual Impact
The badges provide immediate visual feedback about:
- Project health and build status
- Current release version
- Adoption metrics through download counts
- Licensing clarity for users
- Dependency maintenance status

### Benefits
- **Quick Status Overview**: Users can instantly assess project status
- **Professional Appearance**: Standard badges improve project credibility
- **Maintenance Transparency**: Shows commitment to keeping dependencies updated
- **License Clarity**: Clear MIT license indication encourages adoption
- **Version Awareness**: Easy access to current release information

## Test plan
- [x] All badge URLs are correct and functional
- [x] Depfu integration confirmed with actual badge ID
- [x] All RuboCop and RSpec checks pass
- [x] README formatting maintained with proper spacing

:robot: Generated with [Claude Code](https://claude.ai/code)