### PR TITLE
:books: Fix RELEASING.md link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ This project uses automated GitHub Actions workflows for releases. Maintainers c
 3. Review and merge the generated PR
 4. Release is automatically published to RubyGems and GitHub
 
-**For detailed instructions, troubleshooting, and setup requirements, see [`.github/RELEASING.md`](.github/RELEASING.md).**
+**For detailed instructions, troubleshooting, and setup requirements, see [`RELEASING.md`](RELEASING.md).**
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary
- Update outdated `.github/RELEASING.md` path to correct `RELEASING.md` path
- Fix broken documentation link in README

## Test plan
- [x] Tests pass
- [x] RuboCop passes

:robot: Generated with [Claude Code](https://claude.ai/code)